### PR TITLE
add webdriver property to pom.xml, e.g. chrome or firefox

### DIFF
--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -16,6 +16,7 @@
         <webapp.url>http://localhost:8080/openmrs</webapp.url>
         <login.username>admin</login.username>
         <login.password>test</login.password>
+        <webdriver>chrome</webdriver>
     </properties>
     <profiles>
         <profile>

--- a/ui-tests/src/main/java/org/openmrs/reference/helper/TestProperties.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/helper/TestProperties.java
@@ -3,33 +3,46 @@ package org.openmrs.reference.helper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.String;
 import java.util.Properties;
 
 public class TestProperties {
-    private Properties properties;
+	
+	private static TestProperties SINGLETON;
 
-    public TestProperties() {
-        properties = new Properties();
-        try {
-            InputStream input = Thread.currentThread().getContextClassLoader()
-                    .getResourceAsStream("org/openmrs/reference/test.properties");
-            properties.load(new InputStreamReader(input, "UTF-8"));
-        }
-        catch (IOException ioException) {
-            throw new RuntimeException("test.properties not found. Error: ", ioException);
-        }
-    }
-
-    public String getWebAppUrl() {
-        return properties.getProperty("webapp.url");
-    }
-
-    public String getUserName(){
-        return properties.getProperty("login.username");
-    }
-
-    public String getPassword(){
-        return properties.getProperty("login.password");
-    }
+	private Properties properties;
+	
+	public static TestProperties instance() {
+		if (SINGLETON == null) {
+			SINGLETON = new TestProperties();
+		}
+		return SINGLETON;
+	}
+	
+	public TestProperties() {
+		properties = new Properties();
+		try {
+			InputStream input = Thread.currentThread().getContextClassLoader()
+			        .getResourceAsStream("org/openmrs/reference/test.properties");
+			properties.load(new InputStreamReader(input, "UTF-8"));
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException("test.properties not found. Error: ", ioException);
+		}
+	}
+	
+	public String getWebAppUrl() {
+		return properties.getProperty("webapp.url");
+	}
+	
+	public String getUserName() {
+		return properties.getProperty("login.username");
+	}
+	
+	public String getPassword() {
+		return properties.getProperty("login.password");
+	}
+	
+	public String getWebDriver() {
+		return properties.getProperty("webdriver");
+	}
 }

--- a/ui-tests/src/main/java/org/openmrs/reference/page/AbstractBasePage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/AbstractBasePage.java
@@ -16,7 +16,7 @@ import org.openqa.selenium.support.ui.Select;
  * elements, clicking, filling fields. etc.
  */
 public abstract class AbstractBasePage implements Page {
-    protected TestProperties properties = new TestProperties();
+    protected TestProperties properties = TestProperties.instance();
     protected WebDriver driver;
     private String serverURL;
 

--- a/ui-tests/src/main/java/org/openmrs/reference/page/LoginPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/LoginPage.java
@@ -1,25 +1,22 @@
 package org.openmrs.reference.page;
 
-import org.openmrs.reference.helper.TestProperties;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
 public class LoginPage extends AbstractBasePage {
 
-    protected TestProperties properties = new TestProperties();
+	static final String userNameTxtBox = "username";
+	static final String passwordTxtBox = "password";
+	static final String loginBtn = "login-button";
+	
     private String UserName;
     private String Password;
-
 
     public LoginPage(WebDriver driver) {
         super(driver);
         UserName = properties.getUserName();
         Password = properties.getPassword();
     }
-
-    private String userNameTxtBox = "username";
-    private String passwordTxtBox = "password";
-    private String loginBtn = "login-button";
 
     public void login(String user, String password) {
         setTextToField(By.id(userNameTxtBox),user);

--- a/ui-tests/src/main/resources/org/openmrs/reference/test.properties
+++ b/ui-tests/src/main/resources/org/openmrs/reference/test.properties
@@ -1,4 +1,4 @@
 webapp.url=${webapp.url}
 login.username=${login.username}
 login.password=${login.password}
-
+webdriver=${webdriver}

--- a/ui-tests/src/test/java/org/openmrs/reference/TestBase.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/TestBase.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.openmrs.reference.helper.TestProperties;
 import org.openmrs.reference.page.GenericPage;
 import org.openmrs.reference.page.Page;
 import org.openqa.selenium.WebDriver;
@@ -15,11 +16,28 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 
 public class TestBase {
+	
+	public enum WebDriverType {chrome, firefox};	// only these two for now
+	
     protected static WebDriver driver;
 
     @BeforeClass
     public static void startWebDriver() {
-        driver = setupChromeDriver(); //setupChromeDriver(); // setupFirefoxDriver();
+        final TestProperties properties = TestProperties.instance();
+        final String webDriverName = properties.getWebDriver();
+        final WebDriverType webDriverType = WebDriverType.valueOf(webDriverName);
+        switch (webDriverType) {
+			case chrome:
+				driver = setupChromeDriver();
+				break;
+			case firefox:
+				driver = setupFirefoxDriver();
+				break;
+			default:
+				// shrug, choose chrome as default
+				driver = setupChromeDriver();
+				break;
+		}
         currentPage().gotoPage("/login.htm");
     }
 


### PR DESCRIPTION
pom.xml now has a "webdriver" property (default is chrome, other value for now is firefox, easy to add more in the future). The UI tests pick up that property and load the right driver. I tried it with both chrome and firefox on Windows (didn't try ubuntu, but should work). I also took the opportunity to clean up the properties-handling code a bit. 
