### PR TITLE
RA-391: Removed reportingui from the refapp distro

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -130,11 +130,6 @@
 									<artifactId>reporting-omod</artifactId>
 									<destFileName>reporting-${reportingVersion}.omod</destFileName>
 								</artifactItem>
-                                <artifactItem>
-                                    <groupId>org.openmrs.module</groupId>
-                                    <artifactId>reportingui-omod</artifactId>
-                                    <destFileName>reportingui-${reportinguiVersion}.omod</destFileName>
-                                </artifactItem>
 								<artifactItem>
 									<groupId>org.openmrs.module</groupId>
 									<artifactId>metadatasharing-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<registrationcoreVersion>1.0</registrationcoreVersion>
 		<registrationappVersion>1.0</registrationappVersion>
 		<eventVersion>2.1</eventVersion>
-		<idgenVersion>2.8-SNAPSHOT</idgenVersion>
+		<idgenVersion>2.9-SNAPSHOT</idgenVersion>
 		<emrapiVersion>1.4-SNAPSHOT</emrapiVersion>
 		<referenceapplicationVersion>2.1-SNAPSHOT</referenceapplicationVersion>
 		<providermanagementVersion>2.1</providermanagementVersion>
@@ -48,7 +48,6 @@
 		<htmlwidgetsVersion>1.6.5</htmlwidgetsVersion>
 		<reportingVersion>0.9.2-SNAPSHOT</reportingVersion>
         <reportingRestVersion>1.3-SNAPSHOT</reportingRestVersion>
-		<reportinguiVersion>1.0-SNAPSHOT</reportinguiVersion>
 		<metadatasharingVersion>1.1.8</metadatasharingVersion>
 		<metadatamappingVersion>1.0.1</metadatamappingVersion>
 		<uicommonsVersion>1.3-SNAPSHOT</uicommonsVersion>
@@ -198,11 +197,6 @@
 				<artifactId>reporting-api</artifactId>
 				<version>${reportingVersion}</version>
 			</dependency>
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>reportingui-api</artifactId>
-                <version>${reportinguiVersion}</version>
-            </dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>metadatasharing-api</artifactId>
@@ -510,11 +504,6 @@
 				<artifactId>reporting-omod</artifactId>
 				<version>${reportingVersion}</version>
 			</dependency>
-            <dependency>
-                <groupId>org.openmrs.module</groupId>
-                <artifactId>reportingui-omod</artifactId>
-                <version>${reportinguiVersion}</version>
-            </dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>metadatasharing-omod</artifactId>


### PR DESCRIPTION
https://issues.openmrs.org/browse/RA-391

Removed reporting ui module and updated idgen version since it was causing build error.
