### PR TITLE
Changing the refapp to the next snapshot for the modules using refapp distro import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<openMRSVersion>1.10.0</openMRSVersion>
-		<referencemetadataVersion>2.1.1</referencemetadataVersion>
+		<referencemetadataVersion>2.2-SNAPSHOT</referencemetadataVersion>
 		<logicVersion>0.5.2</logicVersion>
 		<appframeworkVersion>2.2.1</appframeworkVersion>
 		<uiframeworkVersion>3.2.1</uiframeworkVersion>
@@ -40,7 +40,7 @@
 		<eventVersion>2.1</eventVersion>
 		<idgenVersion>2.9.1</idgenVersion>
 		<emrapiVersion>1.5-SNAPSHOT</emrapiVersion>
-		<referenceapplicationVersion>2.1.1</referenceapplicationVersion>
+		<referenceapplicationVersion>2.2-SNAPSHOT</referenceapplicationVersion>
 		<providermanagementVersion>2.2</providermanagementVersion>
 		<uilibraryVersion>2.0.4</uilibraryVersion>
 		<calculationVersion>1.1</calculationVersion>
@@ -51,19 +51,19 @@
         <metadatadeployVersion>1.2</metadatadeployVersion>
 		<metadatasharingVersion>1.1.8</metadatasharingVersion>
 		<metadatamappingVersion>1.0.1</metadatamappingVersion>
-		<uicommonsVersion>1.3</uicommonsVersion>
-		<appuiVersion>1.2.2</appuiVersion>
+		<uicommonsVersion>1.4-SNAPSHOT</uicommonsVersion>
+		<appuiVersion>1.3-SNAPSHOT</appuiVersion>
 		<htmlformentryVersion>2.4</htmlformentryVersion>
 		<htmlformentry19extVersion>1.4</htmlformentry19extVersion>
 		<htmlformentryuiVersion>1.1</htmlformentryuiVersion>
 		<coreappsVersion>1.5-SNAPSHOT</coreappsVersion>
 		<webservices.restVersion>2.7-SNAPSHOT</webservices.restVersion>
-		<referencedemodataVersion>1.3</referencedemodataVersion>
+		<referencedemodataVersion>1.4-SNAPSHOT</referencedemodataVersion>
 		<namephoneticsVersion>1.4</namephoneticsVersion>
 		<dataexchangeVersion>1.2</dataexchangeVersion>
 		<allergyapiVersion>1.1-SNAPSHOT</allergyapiVersion>
 		<allergyuiVersion>1.1-SNAPSHOT</allergyuiVersion>
-		<formentryappVersion>1.0</formentryappVersion>
+		<formentryappVersion>1.1-SNAPSHOT</formentryappVersion>
 		<atlasVersion>2.1</atlasVersion>
 	</properties>
 


### PR DESCRIPTION
With this pom, I was able to install coreapps and emrapi from a clean maven repo (removed org/openmrs folder from my maven local repo). 

I was able to reprovision the refapp distro from scratch. All the modules were loaded, so I guess everything might be working. 

All repos from [using the refapp distro import](https://github.com/openmrs/openmrs-contrib-bamboo/blob/master/list-repos-using-refapp-import.txt) should be now pointing to a version that can be actually used from maven. 
