### PR TITLE
GCI-4 - Login Info Tests

### DIFF
--- a/ui-tests/src/main/java/org/openmrs/reference/page/HomePage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/HomePage.java
@@ -1,8 +1,22 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
 package org.openmrs.reference.page;
 
 import org.openmrs.uitestframework.page.AbstractBasePage;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 public class HomePage extends AbstractBasePage {
 	
@@ -14,6 +28,8 @@ public class HomePage extends AbstractBasePage {
     static final String CONFIGURE_METADATA_APP_ID = "coreapps-configuremetadata-homepageLink-coreapps-configuremetadata-homepageLink-extension";
 	static final String DISPENSING_MEDICATION_APP_ID = "dispensing-app-homepageLink-dispensing-app-homepageLink-extension";
 	static final String CAPTURE_VITALS_APP_ID = "referenceapplication-vitals-referenceapplication-vitals-extension";
+	static final String HOME_CONTAINER = "home-container";
+	static final String CANT_LOGIN = "cant-login";
 	
 	public HomePage(WebDriver driver) {
 		super(driver);
@@ -77,6 +93,17 @@ public class HomePage extends AbstractBasePage {
 	public boolean isCaptureVitalsAppPresent() {
 		return isAppButtonPresent(CAPTURE_VITALS_APP_ID);
     }
+	
+	public String getLoggedAsString() {
+		WebElement container = driver.findElement(By.id(HOME_CONTAINER));
+		WebElement text = container.findElement(By.xpath("id('home-container')/h4"));
+		return text.getText();
+	}
+	
+	public void pressCantLogin() {
+		WebElement button = driver.findElement(By.id(CANT_LOGIN));
+		button.click();
+	}
 
 	@Override
 	public String expectedUrlPath() {

--- a/ui-tests/src/main/java/org/openmrs/reference/page/LocationPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/LocationPage.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.reference.page;
+
+import java.util.List;
+
+import org.openmrs.uitestframework.page.AbstractBasePage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class LocationPage extends AbstractBasePage {
+
+	private static final By USERNAME = By.id("username");
+	private static final By PASSWORD = By.id("password");
+	private static final By LOGIN = By.id("login-button");
+	private static final By LOCATION_LIST = By.id("sessionLocation");
+	
+	private static final String LOGOUT_PATH = "/logout";
+	
+	public LocationPage(WebDriver driver) {
+		super(driver);
+	}
+	
+	public String getLocationName(int index) {
+		WebElement locationList = driver.findElement(LOCATION_LIST);
+		List<WebElement> locationCollection = locationList.findElements(By.xpath("id('sessionLocation')/li"));
+		return locationCollection.get(index).getText();
+	}
+	
+	public void clickOnLocation(int index) {
+		WebElement locationList = driver.findElement(LOCATION_LIST);
+		List<WebElement> locationCollection = locationList.findElements(By.xpath("id('sessionLocation')/li"));
+		locationCollection.get(index).click();
+	}
+	
+	public void loginWithoutChooseLocation() {
+		// We can simple use login() after clickOnLocation(), but by default login() selects the first location
+		setTextToFieldNoEnter(USERNAME, properties.getUserName());
+		setTextToFieldNoEnter(PASSWORD, properties.getPassword());
+		clickOn(LOGIN);
+		findElement(byFromHref(URL_ROOT + LOGOUT_PATH));	// this waits until the Logoff link is present
+	}
+	
+	public void loginWithNewPassword(String password) {
+		setTextToFieldNoEnter(USERNAME, properties.getUserName());
+		setTextToFieldNoEnter(PASSWORD, password);
+		clickOn(LOGIN);
+		findElement(byFromHref(URL_ROOT + LOGOUT_PATH));	// this waits until the Logoff link is present
+	}
+
+	@Override
+	public String expectedUrlPath() {
+		return URL_ROOT + "/openmrs/login.htm";
+	}
+
+}

--- a/ui-tests/src/main/java/org/openmrs/reference/page/UserOptionsPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/UserOptionsPage.java
@@ -1,0 +1,64 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.reference.page;
+
+import java.util.List;
+
+import org.openmrs.uitestframework.page.AbstractBasePage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class UserOptionsPage extends AbstractBasePage {
+
+	private static final By OPTSECTION_1 = By.id("optsection-1");
+	private static final By OPTIONS_LIST = By.id("optionsTOC");
+	
+	public static String URL_PAGE = "/options.form";
+	
+	public UserOptionsPage(WebDriver driver) {
+		super(driver);
+	}
+	
+	public void pressChangeLoginInfo() {
+		WebElement table = driver.findElement(OPTIONS_LIST);
+		List<WebElement> liCollection = table.findElements(By.xpath("id('optionsTOC')/li"));
+		liCollection.get(1).click();
+	}
+	
+	public String getUserOption(int trIndex) {
+		WebElement table = driver.findElement(OPTSECTION_1);
+		List<WebElement> inputCollection = table.findElements(By.xpath("id('optsection-1')/table/tbody/tr/td/input"));
+		return inputCollection.get(trIndex).getAttribute("value");
+	}
+	
+	public void pasteNewUserOption(int trIndex, String option) {
+		WebElement table = driver.findElement(OPTSECTION_1);
+		List<WebElement> inputCollection = table.findElements(By.xpath("id('optsection-1')/table/tbody/tr/td/input"));
+		inputCollection.get(trIndex).clear();
+		inputCollection.get(trIndex).sendKeys(option);
+	}
+	
+	public void saveOptions() {
+		WebElement content = driver.findElement(By.id("content"));
+		WebElement button = content.findElement(By.xpath("id('content')/form/input"));
+		button.click();
+	}
+
+	@Override
+	public String expectedUrlPath() {
+		return URL_ROOT + URL_PAGE;
+	}
+
+}

--- a/ui-tests/src/test/java/org/openmrs/reference/ChangeLoginInfoTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/ChangeLoginInfoTest.java
@@ -1,0 +1,354 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.reference;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openmrs.reference.page.HeaderPage;
+import org.openmrs.reference.page.HomePage;
+import org.openmrs.reference.page.LocationPage;
+import org.openmrs.reference.page.UserOptionsPage;
+import org.openmrs.uitestframework.test.TestBase;
+import org.openqa.selenium.JavascriptExecutor;
+
+public class ChangeLoginInfoTest extends TestBase {
+	private HeaderPage headerPage;
+	private HomePage homePage;
+	private LocationPage locationPage;
+	private UserOptionsPage userOptionsPage;
+	private Random rand;
+	
+	private static final String ADMIN_PASSWORD = "Admin123";
+	private static final String NEW_ADMIN_PASSWORD = "123Admin_1";
+	
+	private static final String[] USER_NAMES = { "Alexandre", "Achint", "Brittany", "Burke", "Cesar", "Cosmin",
+        "Daniel", "Darius", "David", "Ellen", "Émerson", "Evan", "Fernando", "Gabou", "Glauber", "Hamish", "Louise",
+        "Mário", "Mark", "Natália", "Neil", "Neissi", "Nelice", "Rafal", "Renee", "Wyclif" };
+	
+	@Before
+	public void before() {
+		headerPage = new HeaderPage(driver);
+        homePage = new HomePage(driver);
+        locationPage = new LocationPage(driver);
+        userOptionsPage = new UserOptionsPage(driver);
+        rand = new Random();
+	}
+	
+	@Test
+	public void changeUsername() {
+		login();
+		assertPage(homePage);
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		int trIndex = 0;
+		
+		// Choose name
+		int index = rand.nextInt(USER_NAMES.length);
+		String newName = USER_NAMES[index];
+		
+		// Change username
+		userOptionsPage.pressChangeLoginInfo();
+		String lastOption = userOptionsPage.getUserOption(trIndex);
+		userOptionsPage.pasteNewUserOption(trIndex, newName);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Check "Logged as" string with new option
+		String loggedAs = homePage.getLoggedAsString();
+		assertTrue(loggedAs.contains(newName));
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		// Backup username
+		userOptionsPage.pressChangeLoginInfo();
+		userOptionsPage.pasteNewUserOption(trIndex, lastOption);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Check "Logged as" string with old option
+		loggedAs = homePage.getLoggedAsString();
+		assertTrue(loggedAs.contains(lastOption));
+		
+		// Logout
+		homePage.go();
+    	assertPage(homePage);
+		headerPage.logOut();
+        assertPage(loginPage);
+	}
+	
+	@Test
+	public void changeGivenName() {
+		login();
+		assertPage(homePage);
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		int trIndex = 1;
+		
+		// Choose name
+		int index = rand.nextInt(USER_NAMES.length);
+		String newName = USER_NAMES[index];
+		
+		// Change given name
+		userOptionsPage.pressChangeLoginInfo();
+		String lastOption = userOptionsPage.getUserOption(trIndex);
+		userOptionsPage.pasteNewUserOption(trIndex, newName);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Check "Logged as" string with new option
+		String loggedAs = homePage.getLoggedAsString();
+		assertTrue(loggedAs.contains(newName));
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		// Backup given name
+		userOptionsPage.pressChangeLoginInfo();
+		userOptionsPage.pasteNewUserOption(trIndex, lastOption);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Check "Logged as" string with old option
+		loggedAs = homePage.getLoggedAsString();
+		assertTrue(loggedAs.contains(lastOption));
+		
+		// Logout
+		homePage.go();
+    	assertPage(homePage);
+		headerPage.logOut();
+        assertPage(loginPage);
+	}
+	
+	@Test
+	public void changeMiddleName() {
+		login();
+		assertPage(homePage);
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		int trIndex = 2;
+		
+		// Choose name
+		int index = rand.nextInt(USER_NAMES.length);
+		String newName = USER_NAMES[index];
+		
+		// Change middle name
+		userOptionsPage.pressChangeLoginInfo();
+		String lastOption = userOptionsPage.getUserOption(trIndex);
+		userOptionsPage.pasteNewUserOption(trIndex, newName);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Check "Logged as" string with new option
+		String loggedAs = homePage.getLoggedAsString();
+		assertTrue(loggedAs.contains(newName));
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		// Backup middle name
+		userOptionsPage.pressChangeLoginInfo();
+		userOptionsPage.pasteNewUserOption(trIndex, lastOption);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Check "Logged as" string with old option
+		loggedAs = homePage.getLoggedAsString();
+		assertTrue(loggedAs.contains(lastOption));
+		
+		// Logout
+		homePage.go();
+    	assertPage(homePage);
+		headerPage.logOut();
+        assertPage(loginPage);
+	}
+	
+	@Test
+	public void changeFamilyName() {
+		login();
+		assertPage(homePage);
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		int trIndex = 3;
+		
+		// Choose name
+		int index = rand.nextInt(USER_NAMES.length);
+		String newName = USER_NAMES[index];
+		
+		// Change middle name
+		userOptionsPage.pressChangeLoginInfo();
+		String lastOption = userOptionsPage.getUserOption(trIndex);
+		userOptionsPage.pasteNewUserOption(trIndex, newName);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Check "Logged as" string with new option
+		String loggedAs = homePage.getLoggedAsString();
+		assertTrue(loggedAs.contains(newName));
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		// Backup middle name
+		userOptionsPage.pressChangeLoginInfo();
+		userOptionsPage.pasteNewUserOption(trIndex, lastOption);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Check "Logged as" string with old option
+		loggedAs = homePage.getLoggedAsString();
+		assertTrue(loggedAs.contains(lastOption));
+		
+		// Logout
+		homePage.go();
+    	assertPage(homePage);
+		headerPage.logOut();
+        assertPage(loginPage);
+	}
+	
+	@Test
+	public void changePassword() {
+		login();
+		assertPage(homePage);
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		// Change password
+		userOptionsPage.pressChangeLoginInfo();
+		userOptionsPage.pasteNewUserOption(4, ADMIN_PASSWORD);
+		userOptionsPage.pasteNewUserOption(5, NEW_ADMIN_PASSWORD);
+		userOptionsPage.pasteNewUserOption(6, NEW_ADMIN_PASSWORD);
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Logout
+		homePage.go();
+		assertPage(homePage);
+		headerPage.logOut();
+		assertPage(loginPage);
+		
+		// Login with new password
+		locationPage.loginWithNewPassword(NEW_ADMIN_PASSWORD);
+		assertPage(homePage);
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		// Backup password
+		userOptionsPage.pressChangeLoginInfo();
+		userOptionsPage.pasteNewUserOption(4, NEW_ADMIN_PASSWORD);
+		userOptionsPage.pasteNewUserOption(5, ADMIN_PASSWORD);
+		userOptionsPage.pasteNewUserOption(6, ADMIN_PASSWORD);
+		userOptionsPage.saveOptions();
+		
+		// Logout
+		homePage.go();
+    	assertPage(homePage);
+		headerPage.logOut();
+        assertPage(loginPage);
+        
+        // Login with old password
+        login();
+		assertPage(homePage);
+		
+		// Logout
+		homePage.go();
+    	assertPage(homePage);
+		headerPage.logOut();
+        assertPage(loginPage);
+	}
+	
+	@Ignore
+	@Test
+	public void changeSecretQuestion() throws InterruptedException {
+		login();
+		assertPage(homePage);
+		
+		// Go to User Options page
+		currentPage().gotoPage(UserOptionsPage.URL_PAGE);
+		assertPage(userOptionsPage);
+		
+		// Change secret question
+		userOptionsPage.pressChangeLoginInfo();
+		userOptionsPage.pasteNewUserOption(7, ADMIN_PASSWORD);
+		userOptionsPage.pasteNewUserOption(8, "How do you do?");
+		userOptionsPage.pasteNewUserOption(9, "all_right");
+		userOptionsPage.pasteNewUserOption(10, "all_right");
+		userOptionsPage.saveOptions();
+		
+		// Go to home page
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs';");
+		
+		// Logout
+		homePage.go();
+		assertPage(homePage);
+		headerPage.logOut();
+		assertPage(loginPage);
+		
+		// Press "Can't log in?"
+		homePage.pressCantLogin();
+		
+		// We need to check our secret question, but it can not cause
+		// TODO: resolve the issue with this test: remove test or realize secret questions
+		Thread.sleep(3000);
+		
+		// Logout
+		homePage.go();
+    	assertPage(homePage);
+		headerPage.logOut();
+        assertPage(loginPage);
+	}
+}


### PR DESCRIPTION
This code tests login info changes

Ticket: http://issues.openmrs.org/browse/GCI-4
Melange task: https://www.google-melange.com/gci/task/view/google/gci2014/5287686071910400
YouTube Video: http://youtu.be/WeJlULfCR4s

6 tests: change username, given name, middle name, family name, password, secret question.
These data changes only during tests, after tests data changes on the old

Classes HomePage.java and LocationPage.java I used in the past pull requests, now I only updated this classes

Test <b>changeSecretQuestion</b> ignored, because we need to check our secret question, but it can not cause
See screenshots
![izm1](https://cloud.githubusercontent.com/assets/5406399/5606137/aba80222-9430-11e4-9e33-5cbb0c6ed2c8.png)
![izm2](https://cloud.githubusercontent.com/assets/5406399/5606136/aba7215e-9430-11e4-9358-2dd6a9e45b4d.png)

we need to do something with this issue (or bug)