### PR TITLE
GCI-4 - Edit Visit Notes Tests

### DIFF
--- a/ui-tests/src/main/java/org/openmrs/reference/page/ActiveVisitsPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/ActiveVisitsPage.java
@@ -1,0 +1,84 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.reference.page;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class ActiveVisitsPage extends SearchPage {
+
+	static final By SEARCH = By.id("active-visits_filter");
+	static final By TABLE = By.id("active-visits");
+	
+	public ActiveVisitsPage(WebDriver driver) {
+		super(driver);
+	}
+	
+	public void clickFirstPatient() {
+		WebElement tableElement = driver.findElement(TABLE);
+		WebElement link = tableElement.findElement(By.xpath("id('active-visits')/tbody/tr[1]/td[2]/a"));
+		link.click();
+	}
+	
+	@Override
+	public void search(String template) {
+		WebElement searchInput = driver.findElement(SEARCH).findElement(By.xpath("id('active-visits_filter')/label/input"));
+		searchInput.clear();
+		searchInput.sendKeys(template);
+	}
+	
+	@Override
+	public List<String> getStringsFromColumn(int column) {
+		// Takes all the strings of this column (e.g. 0 - Identifier, 1 - Name)
+		List<String> list = new ArrayList<String>();
+		WebElement tableElement = driver.findElement(TABLE);
+		List<WebElement> tr_collection = tableElement.findElements(By.xpath("id('active-visits')/tbody/tr"));
+		
+        for(WebElement trElement : tr_collection) {
+            List<WebElement> td_collection = trElement.findElements(By.xpath("td"));
+            String patient = td_collection.get(column).getText();
+            list.add(patient);
+        }
+        
+        return list;
+	}
+	
+	@Override
+	public boolean verifyTable(int column, String template) throws Exception {
+		Thread.sleep(1500); 	// A little hack - we have to wait until the table is fully loaded
+		WebElement tableElement = driver.findElement(TABLE);
+		List<WebElement> tr_collection = tableElement.findElements(By.xpath("id('active-visits')/tbody/tr"));
+		
+        for(WebElement trElement : tr_collection) {
+            List<WebElement> td_collection = trElement.findElements(By.xpath("td"));
+            String patient = td_collection.get(column).getText();
+            
+            if(patient.indexOf(template) == -1) {
+            	return false;
+            }
+        }
+        
+        return true;
+	}
+
+	@Override
+	public String expectedUrlPath() {
+		return URL_ROOT + "/coreapps/activeVisits.page";
+	}
+
+}

--- a/ui-tests/src/main/java/org/openmrs/reference/page/PatientDashboardPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/PatientDashboardPage.java
@@ -1,7 +1,23 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
 package org.openmrs.reference.page;
+
+import java.util.List;
 
 import org.openmrs.uitestframework.page.AbstractBasePage;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -14,17 +30,200 @@ public class PatientDashboardPage extends AbstractBasePage {
 	private static final By CONFIRM = By.cssSelector("#quick-visit-creation-dialog .confirm");
 	private static final By STARTED_AT = By.className("active-visit-started-at-message");
 	private static final By VISIT_NOTE = By.id("referenceapplication.realTime.simpleVisitNote");
+	private static final By CAPTURE_VITALS = By.id("referenceapplication.realTime.vitals");
 	private static final By DIAGNOSIS_SEARCH_CONTAINER = By.id("diagnosis-search-container");
 	private static final By DIAGNOSIS_SEARCH = By.id("diagnosis-search");
-
+	private static final By CONTENT = By.id("content");
+	
+	private static final By VITALS_HEIGHT = By.id("height");
+	private static final By VITALS_WEIGHT = By.id("weight");
+	private static final By VITALS_TEMPERATURE = By.id("temperature");
+	private static final By VITALS_HEART_RATE = By.id("heart_rate");
+	private static final By VITALS_RESPIRATORY_RATE = By.id("respiratory_rate");
+	private static final By VITALS_BP_SYSTOLIC = By.id("bp_systolic");
+	private static final By VITALS_BP_DIASTOLIC = By.id("bp_diastolic");
+	private static final By VITALS_OXYGEN_SATURATION = By.id("o2_sat");
+	
 	public PatientDashboardPage(WebDriver driver) {
 	    super(driver);
     }
+	
+	public void editDemographics() {
+		WebElement content = driver.findElement(CONTENT);
+		WebElement editButton = content.findElement(By.xpath("id('content')/div[5]/div[1]/h1/span[3]/span[3]"));
+		editButton.click();
+	}
+	
+	public void editContactInfo() {
+		WebElement contactInfoContent = driver.findElement(By.id("contactInfoContent"));
+		WebElement editContactInfoButton = contactInfoContent.findElement(By.xpath("id('contactInfoContent')/div/small"));
+		editContactInfoButton.click();
+	}
+	
+	public String getGivenName() {
+		WebElement content = driver.findElement(CONTENT);
+		WebElement span = content.findElement(By.xpath("id('content')/div[5]/div[1]/h1/span[2]"));
+		return span.getText().split("\\s+")[0];
+	}
+	
+	public String getFamilyName() {
+		WebElement content = driver.findElement(CONTENT);
+		WebElement span = content.findElement(By.xpath("id('content')/div[5]/div[1]/h1/span[1]"));
+		String family = span.getText().split("\\s+")[0];
+		family = family.substring(0, family.length() - 1);	// delete last character ','
+		return family;
+	}
+	
+	public String getGender() {
+		WebElement content = driver.findElement(CONTENT);
+		WebElement span = content.findElement(By.xpath("id('content')/div[5]/div[1]/h1/span[3]/span[1]"));
+		return span.getText();
+	}
+
+	public String[] getBirthdateData() {
+		WebElement content = driver.findElement(CONTENT);
+		WebElement span = content.findElement(By.xpath("id('content')/div[5]/div[1]/h1/span[3]/span[2]"));
+		
+		String data = span.getText().split("\\s+")[2];
+		data = data.substring(1, data.length() - 1);
+		
+		return data.split("\\.");
+	}
+	
+	public String[] getAddressData() {
+		WebElement contactInfoContent = driver.findElement(By.id("contactInfoContent"));
+		WebElement span = contactInfoContent.findElement(By.xpath("id('contactInfoContent')/div/span[1]"));
+		
+		String[] address = span.getText().split("\\s+");
+		
+		address[0] = address[0].substring(0, address[0].length() - 1);	// remove ','
+		address[1] = address[1].substring(0, address[1].length() - 1);	// remove ','
+		
+		return address;
+	}
+	
+	public String getPhoneNumber() {
+		WebElement contactInfoContent = driver.findElement(By.id("contactInfoContent"));
+		WebElement span = contactInfoContent.findElement(By.xpath("id('contactInfoContent')/div/span[2]"));
+		String[] text = span.getText().split("\\s+");
+		return text[0];
+	}
+	
+	public void showContactInfo() {
+		WebElement showContactInfoButton = driver.findElement(By.id("patient-header-contactInfo"));
+		showContactInfoButton.click();
+	}
 
 	public void startVisit() {
 		clickOn(START_VISIT);
 		waitForElement(CONFIRM);
 		clickOn(CONFIRM);
+	}
+	
+	public void captureVitals() {
+		clickOn(CAPTURE_VITALS);
+	}
+	
+	public void clickVisitAction(int index) {
+		WebElement content = driver.findElement(CONTENT);
+		List<WebElement> liCollection = content.findElements(By.xpath("id('content')/div[8]/div/div[3]/div[1]/ul[1]/li"));
+		liCollection.get(index).click();
+	}
+	
+	public void clickGeneralAction(int index) {
+		WebElement content = driver.findElement(CONTENT);
+		List<WebElement> aCollection = content.findElements(By.xpath("id('content')/div[8]/div/div[3]/div[1]/ul[2]/a"));
+		aCollection.get(index).click();
+	}
+	
+	public boolean containsInDiagnosis(String diagnosis) {
+		WebElement content = driver.findElement(CONTENT);
+		List<WebElement> liCollection = content.findElements(By.xpath("id('content')/div[8]/div/div[1]/div[1]/div[2]/ul/li"));
+		
+		for (WebElement li : liCollection) {
+			if(li.getText().equals(diagnosis)) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+	
+	public void gotoDashboard(String currPage) {
+		currPage = currPage.substring(currPage.indexOf('?') + 1);
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs/coreapps/clinicianfacing/patient.page?" + currPage + "';");
+	}
+	
+	public void editVisits(String currPage) {
+		currPage = currPage.substring(currPage.indexOf('?') + 1);
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs/coreapps/patientdashboard/patientDashboard.page?" +
+				currPage + "&#visits';");
+	}
+	
+	public void editAllergies(String currPage) {
+		currPage = currPage.substring(currPage.indexOf('?') + 1);
+		((JavascriptExecutor) driver).executeScript("location.href='/openmrs/allergyui/allergies.page?" + currPage + "';");
+	}
+	
+	public String getAllergen() {
+		WebElement span = driver.findElement(By.className("allergen"));
+		return span.getText();
+	}
+	
+	public String getAllergyReaction() {
+		WebElement span = driver.findElement(By.className("allergyReaction"));
+		return span.getText();
+	}
+	
+	public String getAllergyReaction(int index) {
+		List<WebElement> span = driver.findElements(By.className("allergyReaction"));
+		return span.get(index).getText();
+	}
+	
+	public String getAllergiesString() {
+		WebElement content = driver.findElement(CONTENT);
+		WebElement span = content.findElement(By.xpath("id('content')/div[8]/div/div[2]/div[2]/div[2]"));
+		return span.getText();
+	}
+	
+	public double getVitalsHeight() {
+		WebElement span = driver.findElement(VITALS_HEIGHT).findElement(By.xpath("id('height')/span"));
+		return Double.parseDouble(span.getText());
+	}
+	
+	public double getVitalsWeight() {
+		WebElement span = driver.findElement(VITALS_WEIGHT).findElement(By.xpath("id('weight')/span"));
+		return Double.parseDouble(span.getText());
+	}
+	
+	public double getVitalsTemperature() {
+		WebElement span = driver.findElement(VITALS_TEMPERATURE).findElement(By.xpath("id('temperature')/span"));
+		return Double.parseDouble(span.getText());
+	}
+	
+	public int getVitalsHeartRate() {
+		WebElement span = driver.findElement(VITALS_HEART_RATE).findElement(By.xpath("id('heart_rate')/span"));
+		return Integer.parseInt(span.getText());
+	}
+	
+	public long getVitalsRespiratoryRate() {
+		WebElement span = driver.findElement(VITALS_RESPIRATORY_RATE).findElement(By.xpath("id('respiratory_rate')/span"));
+		return Long.parseLong(span.getText());
+	}
+	
+	public int getVitalsBpSystolic() {
+		WebElement span = driver.findElement(VITALS_BP_SYSTOLIC).findElement(By.xpath("id('bp_systolic')/span"));
+		return Integer.parseInt(span.getText());
+	}
+	
+	public int getVitalsBpDiastolic() {
+		WebElement span = driver.findElement(VITALS_BP_DIASTOLIC).findElement(By.xpath("id('bp_diastolic')/span"));
+		return Integer.parseInt(span.getText());
+	}
+	
+	public int getVitalsOxygenSaturation() {
+		WebElement span = driver.findElement(VITALS_OXYGEN_SATURATION).findElement(By.xpath("id('o2_sat')/span"));
+		return Integer.parseInt(span.getText());
 	}
 	
 	@Override

--- a/ui-tests/src/main/java/org/openmrs/reference/page/VisitNotesPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/VisitNotesPage.java
@@ -1,0 +1,147 @@
+package org.openmrs.reference.page;
+
+import org.openmrs.uitestframework.page.AbstractBasePage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+
+public class VisitNotesPage extends AbstractBasePage {
+
+	private static final By ENCOUNTERS_LIST = By.id("encountersList");
+	private static final By DELETE_DIALOG = By.id("delete-encounter-dialog");
+	private static final By PROVIDER_LIST = By.id("w1");
+	private static final By LOCATION_LIST = By.id("w3");
+	private static final By DIAGNOSES_CONTAINER = By.id("display-encounter-diagnoses-container");
+	private static final By VISITS_LIST = By.id("visits-list");
+	
+	public VisitNotesPage(WebDriver driver) {
+		super(driver);
+	}
+	
+	public String getAllDiagnosesString() {
+		WebElement visitsList = driver.findElement(VISITS_LIST);
+		WebElement span = visitsList.findElement(By.xpath("id('visits-list')/li/span[2]"));
+		return span.getText();
+	}
+	
+	public void deleteLastVisitNote() {
+		waitForElement(ENCOUNTERS_LIST);
+		WebElement encountersList = driver.findElement(ENCOUNTERS_LIST);
+		WebElement deleteButton = encountersList.findElement(By.xpath("id('encountersList')/li[1]/span/i[2]"));
+		deleteButton.click();
+		WebElement deleteDialog = driver.findElement(DELETE_DIALOG);
+		WebElement yesButton = deleteDialog.findElement(By.xpath("id('delete-encounter-dialog')/div[2]/button[1]"));
+		yesButton.click();
+	}
+	
+	public void editLastVisitNote() {
+		waitForElement(ENCOUNTERS_LIST);
+		WebElement encountersList = driver.findElement(ENCOUNTERS_LIST);
+		WebElement editButton = encountersList.findElement(By.xpath("id('encountersList')/li[1]/span/i[1]"));
+		editButton.click();
+	}
+	
+	public void showDetails() {
+		waitForElement(ENCOUNTERS_LIST);
+		WebElement encountersList = driver.findElement(ENCOUNTERS_LIST);
+		WebElement detailsLink = encountersList.findElement(By.xpath("id('encountersList')/li[1]/ul/li[3]/div/a"));
+		detailsLink.click();
+	}
+	
+	public String getNote() {
+		waitForElement(ENCOUNTERS_LIST);
+		WebElement encountersList = driver.findElement(ENCOUNTERS_LIST);
+		WebElement span = encountersList.findElement(By.xpath("id('encountersList')/li[1]/div/div/p[2]/span"));
+		return span.getText();
+	}
+	
+	public void editChooseProvider(int index) {
+		WebElement providerList = driver.findElement(PROVIDER_LIST);
+		Select select = new Select(providerList);
+		select.selectByIndex(index);
+	}
+	
+	public String editGetProviderName() {
+		// get name from edit page
+		WebElement providerList = driver.findElement(PROVIDER_LIST);
+		Select select = new Select(providerList);
+		WebElement option = select.getFirstSelectedOption();
+		return option.getText();
+	}
+	
+	public String getProviderName() {
+		// get name from dashboard
+		waitForElement(ENCOUNTERS_LIST);
+		WebElement encountersList = driver.findElement(ENCOUNTERS_LIST);
+		WebElement strong = encountersList.findElement(By.xpath("id('encountersList')/li[1]/ul/li[2]/div/strong[1]"));
+		return strong.getText();
+	}
+	
+	public void editChooseSessionLocation(int index) {
+		WebElement sessionLocationList = driver.findElement(LOCATION_LIST);
+		Select select = new Select(sessionLocationList);
+		select.selectByIndex(index);
+	}
+	
+	public void editChooseSessionLocation(String name) {
+		WebElement sessionLocationList = driver.findElement(LOCATION_LIST);
+		Select select = new Select(sessionLocationList);
+		select.selectByVisibleText(name);
+	}
+	
+	public String editGetSessionLocation() {
+		// get name from edit page
+		WebElement sessionLocationList = driver.findElement(LOCATION_LIST);
+		Select select = new Select(sessionLocationList);
+		WebElement option = select.getFirstSelectedOption();
+		return option.getText();
+	}
+
+	public String getSessionLocation() {
+		// get name from dashboard
+		waitForElement(ENCOUNTERS_LIST);
+		WebElement encountersList = driver.findElement(ENCOUNTERS_LIST);
+		WebElement strong = encountersList.findElement(By.xpath("id('encountersList')/li[1]/ul/li[2]/div/strong[2]"));
+		return strong.getText();
+	}
+	
+	public void editDeleteDiagnosis() {
+		WebElement container = driver.findElement(DIAGNOSES_CONTAINER);
+		WebElement deleteButton = container.findElement(By.xpath("id('display-encounter-diagnoses-container')"
+				+ "/ul[1]/li/span/i"));
+		deleteButton.click();
+	}
+	
+	public String editGetDiagnosis() {
+		// get name from edit page
+		WebElement container = driver.findElement(DIAGNOSES_CONTAINER);
+		WebElement strong = container.findElement(By.xpath("id('display-encounter-diagnoses-container')"
+				+ "/ul[1]/li/span/div/strong"));
+		return strong.getText();
+	}
+	
+	public String getDiagnosis() {
+		// get name from dashboard
+		waitForElement(ENCOUNTERS_LIST);
+		WebElement encountersList = driver.findElement(ENCOUNTERS_LIST);
+		WebElement span = encountersList.findElement(By.xpath("id('encountersList')/li[1]/div/div/p[1]/span"));
+		return span.getText();
+	}
+	
+	public void checkDiagnosisState(boolean confirmed) {
+		WebElement container = driver.findElement(DIAGNOSES_CONTAINER);
+		WebElement checkbox = container.findElement(By.xpath("id('display-encounter-diagnoses-container')"
+				+ "/ul[1]/li/span/div/div/label[2]/input"));
+		
+		if(checkbox.isSelected() != confirmed) {
+			checkbox.click();
+		}
+	}
+	
+	@Override
+	public String expectedUrlPath() {
+		return null;
+	}
+
+}

--- a/ui-tests/src/test/java/org/openmrs/reference/EditVisitNoteTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/EditVisitNoteTest.java
@@ -1,0 +1,209 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.reference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Random;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.reference.page.ActiveVisitsPage;
+import org.openmrs.reference.page.HeaderPage;
+import org.openmrs.reference.page.HomePage;
+import org.openmrs.reference.page.PatientDashboardPage;
+import org.openmrs.reference.page.VisitNotesPage;
+import org.openmrs.uitestframework.test.TestBase;
+
+public class EditVisitNoteTest extends TestBase {
+	
+	private HeaderPage headerPage;
+	private HomePage homePage;
+	private ActiveVisitsPage activeVisitsPage;
+	private PatientDashboardPage patientDashboardPage;
+	private VisitNotesPage visitNotesPage;
+	private Random rand;
+	
+	private static final String DIAGNOSIS = "Pneumonia";
+	private static final String NOTE = "This is a note";
+	private static final String PROVIDER_NAME = "Super User";
+	private static final String CONFIRMED = "Confirmed";
+	private static final String PRESUMED = "Presumed";
+	private static final String EDITED_DIAGNOSIS = "Psychosomatic problems";
+	private static final String EDITED_NOTE = "This is an edited note";
+	
+	@Before
+	public void before() {
+		headerPage = new HeaderPage(driver);
+        homePage = new HomePage(driver);
+        activeVisitsPage = new ActiveVisitsPage(driver);
+        patientDashboardPage = new PatientDashboardPage(driver);
+        visitNotesPage = new VisitNotesPage(driver);
+        rand = new Random();
+        
+        // Login
+        login();
+        assertPage(homePage);
+        
+        // Go to Active Visits page
+        currentPage().gotoPage("/coreapps/activeVisits.page?app=coreapps.activeVisits");
+    	assertPage(activeVisitsPage);
+		
+    	// Choose first patient
+    	activeVisitsPage.clickFirstPatient();
+    	assertPage(patientDashboardPage);
+        
+    	// Create template visit note
+		patientDashboardPage.visitNote();
+		patientDashboardPage.enterDiagnosis(DIAGNOSIS);
+		Assert.assertEquals(DIAGNOSIS, patientDashboardPage.primaryDiagnosis());
+		patientDashboardPage.enterNote(NOTE);
+		patientDashboardPage.save();
+		Assert.assertEquals("Today", patientDashboardPage.visitLink().getText().trim());
+		
+		// Go to edit visits page
+		patientDashboardPage.editVisits(driver.getCurrentUrl());
+	}
+	
+	@After
+    public void after() {
+		// Delete last visit
+		patientDashboardPage.editVisits(driver.getCurrentUrl());
+		visitNotesPage.deleteLastVisitNote();
+		
+		homePage.go();
+		assertPage(homePage);
+		
+		headerPage.logOut();
+		assertPage(loginPage);
+    }
+	
+	@Test
+	public void changeNoteTest() {
+		// Edit note
+        visitNotesPage.editLastVisitNote();
+        patientDashboardPage.enterNote(EDITED_NOTE);
+		patientDashboardPage.save();
+		
+		// Check edited note
+		visitNotesPage.showDetails();
+		assertEquals(visitNotesPage.getNote(), EDITED_NOTE);
+		
+		// Return old note
+		visitNotesPage.editLastVisitNote();
+        patientDashboardPage.enterNote(NOTE);
+		patientDashboardPage.save();
+		
+		// Check old note
+		visitNotesPage.showDetails();
+		assertEquals(visitNotesPage.getNote(), NOTE);
+	}
+	
+	@Test
+	public void changeProviderTest() {
+		// Edit provider
+        visitNotesPage.editLastVisitNote();
+        visitNotesPage.editChooseProvider(rand.nextInt(3) + 1);
+        String providerName = visitNotesPage.editGetProviderName();
+		patientDashboardPage.save();
+		
+		// Check new provider
+		assertEquals(visitNotesPage.getProviderName(), providerName);
+		
+		// Return old provider
+		visitNotesPage.editLastVisitNote();
+        visitNotesPage.editChooseProvider(4);
+		patientDashboardPage.save();
+		
+		// Check old provider
+		assertEquals(visitNotesPage.getProviderName(), PROVIDER_NAME);
+	}
+	
+	@Test
+	public void changeSessionLocationTest() {
+		// Edit location
+        visitNotesPage.editLastVisitNote();
+        String oldLocationName = visitNotesPage.editGetSessionLocation();
+        visitNotesPage.editChooseSessionLocation(rand.nextInt(7));
+        String newLocationName = visitNotesPage.editGetSessionLocation();
+		patientDashboardPage.save();
+		
+		// Check new location
+		assertEquals(visitNotesPage.getSessionLocation(), newLocationName);
+		
+		// Return old location
+		visitNotesPage.editLastVisitNote();
+		visitNotesPage.editChooseSessionLocation(oldLocationName);
+		patientDashboardPage.save();
+		
+		// Check old location
+		assertEquals(visitNotesPage.getSessionLocation(), oldLocationName);
+	}
+	
+	@Test
+	public void changeDiagnosisTest() {
+		// Edit diagnosis
+        visitNotesPage.editLastVisitNote();
+        visitNotesPage.editDeleteDiagnosis();
+        patientDashboardPage.enterDiagnosis(EDITED_DIAGNOSIS);
+		assertEquals(EDITED_DIAGNOSIS, patientDashboardPage.primaryDiagnosis());
+		patientDashboardPage.save();
+		
+		// Check new diagnosis
+		visitNotesPage.showDetails();
+		assertTrue(visitNotesPage.getDiagnosis().contains(EDITED_DIAGNOSIS));
+		assertTrue(visitNotesPage.getAllDiagnosesString().contains(EDITED_DIAGNOSIS));
+		patientDashboardPage.gotoDashboard(driver.getCurrentUrl());
+		assertTrue(patientDashboardPage.containsInDiagnosis(EDITED_DIAGNOSIS));
+		patientDashboardPage.editVisits(driver.getCurrentUrl());
+		
+		// Return old diagnosis
+		visitNotesPage.editLastVisitNote();
+		visitNotesPage.editDeleteDiagnosis();
+		patientDashboardPage.enterDiagnosis(DIAGNOSIS);
+		patientDashboardPage.save();
+		
+		// Check old diagnosis
+		visitNotesPage.showDetails();
+		assertTrue(visitNotesPage.getDiagnosis().contains(DIAGNOSIS));
+		assertTrue(visitNotesPage.getAllDiagnosesString().contains(DIAGNOSIS));
+		patientDashboardPage.gotoDashboard(driver.getCurrentUrl());
+		assertTrue(patientDashboardPage.containsInDiagnosis(DIAGNOSIS));
+		patientDashboardPage.editVisits(driver.getCurrentUrl());
+	}
+	
+	@Test
+	public void changeDiagnosisStateTest() {
+		// Edit diagnosis state
+        visitNotesPage.editLastVisitNote();
+        visitNotesPage.checkDiagnosisState(true);
+		patientDashboardPage.save();
+		
+		// Check new diagnosis state
+		visitNotesPage.showDetails();
+		assertTrue(visitNotesPage.getDiagnosis().contains(CONFIRMED));
+		
+		// Return old diagnosis state
+		visitNotesPage.editLastVisitNote();
+		visitNotesPage.checkDiagnosisState(false);
+		patientDashboardPage.save();
+		
+		// Check old diagnosis state
+		visitNotesPage.showDetails();
+		assertTrue(visitNotesPage.getDiagnosis().contains(PRESUMED));
+	}
+}


### PR DESCRIPTION
Edit Visit Notes Tests

Ticket: http://issues.openmrs.org/browse/GCI-4
Melange task: https://www.google-melange.com/gci/task/view/google/gci2014/5330144977747968
YouTube Video: http://youtu.be/1AfBDMYwcoQ

Five tests: change clinical note, change provider, change session location, change diagnosis name, change diagnosis state (Confirmed/Presumed)
These test visit note used only during tests, after tests this note removed
Classes PatientDashboardPage.java and ActiveVisitsPage.java I used in the past pull requests, now I only updated this classes