### PR TITLE
RA-819: Replace WebDriverWait by Thread.sleep() for waiting result table

### DIFF
--- a/ui-tests/src/main/java/org/openmrs/reference/page/FindPatientPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/FindPatientPage.java
@@ -8,18 +8,15 @@ package org.openmrs.reference.page;
 import org.openmrs.uitestframework.page.AbstractBasePage;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class FindPatientPage extends AbstractBasePage {
 
-    public static final String DATA_TABLES_EMPTY = ".dataTables_empty";
     public static final By PATIENT_SEARCH_RESULT = By.id("patient-search-results-table");
     public static final By PATIENT_NAME_SEARCH_RESULT = By.xpath("//table[@id='patient-search-results-table']/tbody/tr/td[2]");
     public static final By PATIENT_ID_SEARCH_RESULT = By.xpath("//table[@id='patient-search-results-table']/tbody/tr/td[1]");
     private static final By PATIENT_SEARCH = By.id("patient-search");
     private static final By PATIENT = By.xpath("//table[@id='patient-search-results-table']/tbody/tr/td[2]");
+    public static final int SLEEP_TIME = 1000; //1 second
 
     public FindPatientPage(WebDriver driver) {
         super(driver);
@@ -40,9 +37,6 @@ public class FindPatientPage extends AbstractBasePage {
         return findElement(PATIENT_ID_SEARCH_RESULT).getText();
     }
 
-    public WebElement nameSearchResult() {
-        return findElement(PATIENT_SEARCH_RESULT);
-    }
 
     
 
@@ -54,11 +48,14 @@ public class FindPatientPage extends AbstractBasePage {
     /**
      * waits for results appear in a table
      */
-    public void waitForResultTable() {
-        WebDriverWait wait = new WebDriverWait(driver, 5);
-        //wait for table to be cleared from previous results
-        wait.until(ExpectedConditions.visibilityOf(findElement(By.cssSelector(DATA_TABLES_EMPTY))));
-        //wait for the first row of the table
-        wait.until(ExpectedConditions.visibilityOf(findElement(PATIENT_NAME_SEARCH_RESULT)));
+    public void waitForResultTable() throws InterruptedException {
+        int sleepTime = SLEEP_TIME;
+        while (sleepTime < SLEEP_TIME * 10) {
+            Thread.sleep(sleepTime);
+            if (findElement(PATIENT_NAME_SEARCH_RESULT) != null) {
+                return;
+            }
+            sleepTime = sleepTime * 2;
+        }
     }
 }

--- a/ui-tests/src/test/java/org/openmrs/reference/FindPatientRecordTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/FindPatientRecordTest.java
@@ -2,7 +2,6 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.page.FindPatientPage;
@@ -43,10 +42,9 @@ public class FindPatientRecordTest extends TestBase {
         headerPage.logOut();
     }
 
-    @Ignore//ignored due to hanging build
     @Test
     @Category(org.openmrs.reference.groups.BuildTests.class)
-    public void testFindPatientRecord() {
+    public void testFindPatientRecord() throws InterruptedException {
         //navigate "find patient record" page
         homePage.clickOnFindPatientRecord();
         findPatientPage.enterPatient(idToSearch);


### PR DESCRIPTION
Hi Tomasz,

I've updated the test, now it use Thread.sleep() with progressive timeout instead of WebDriverWait. But I still think that the previous version should work correct. May be 5 second timeout in line 
WebDriverWait wait = new WebDriverWait(driver, 5) 
was not enough.