### PR TITLE
Update idgen to 4.3 RA-1084

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<registrationcoreVersion>1.4</registrationcoreVersion>
 		<registrationappVersion>1.5</registrationappVersion>
 		<eventVersion>2.3</eventVersion>
-		<idgenVersion>3.2</idgenVersion>
+		<idgenVersion>4.3</idgenVersion>
 		<emrapiVersion>1.13</emrapiVersion>
 		<referenceapplicationVersion>2.4-SNAPSHOT</referenceapplicationVersion>
 		<providermanagementVersion>2.4</providermanagementVersion>


### PR DESCRIPTION
devtest01 isn’t letting me run UI tests because it can’t boot up the
registration modules due to idgen not being up to date. This fixes that.