### PR TITLE
RA-1102 Improved reliability of AddDiagnosisToVisitNoteTest

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddDiagnosisToVisitNoteTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddDiagnosisToVisitNoteTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
 import org.openmrs.reference.page.ClinicianFacingPatientDashboardPage;
@@ -25,7 +24,6 @@ public class AddDiagnosisToVisitNoteTest extends ReferenceApplicationTestBase {
     private VisitNotePage visitNotePage;
     
     @Test
-    @Ignore //unstable
     @Category(BuildTests.class)
     public void AddDiagnosisToVisitNoteTest() throws Exception {
     	
@@ -36,8 +34,6 @@ public class AddDiagnosisToVisitNoteTest extends ReferenceApplicationTestBase {
         assertEquals("Pneumonia", visitNotePage.primaryDiagnosis());
         assertEquals("Bleeding", visitNotePage.secondaryDiagnosis());
         visitNotePage.save();
-        assertNotNull(patientDashboardPage.visitLink());
-        patientDashboardPage.endVisit();
-
+        assertNotNull(patientDashboardPage.endVisitLink());
     }
 }


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/RA-1102
- Removed end visit at end of test so that the number of patients in active visits wont decrease
- Detect end visit link (which will always be there if page is returned successfully), rather than success toast