### PR TITLE
Bump metadatamapping, emrapi, xstream versions due to MAP-19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,18 +39,18 @@
 		<registrationappVersion>1.5</registrationappVersion>
 		<eventVersion>2.5-SNAPSHOT</eventVersion>
 		<idgenVersion>4.3</idgenVersion>
-		<emrapiVersion>1.16</emrapiVersion>
+		<emrapiVersion>1.17-SNAPSHOT</emrapiVersion>
 		<referenceapplicationVersion>2.5-SNAPSHOT</referenceapplicationVersion>
 		<providermanagementVersion>2.4</providermanagementVersion>
 		<uilibraryVersion>2.0.4</uilibraryVersion>
 		<calculationVersion>1.2</calculationVersion>
-		<serialization.xstreamVersion>0.2.11</serialization.xstreamVersion>
+		<serialization.xstreamVersion>0.2.12-SNAPSHOT</serialization.xstreamVersion>
 		<htmlwidgetsVersion>1.7.2</htmlwidgetsVersion>
 		<reportingVersion>0.10.1</reportingVersion>
 		<reportingRestVersion>1.6</reportingRestVersion>
 		<metadatadeployVersion>1.7</metadatadeployVersion>
 		<metadatasharingVersion>1.2.2-SNAPSHOT</metadatasharingVersion>
-		<metadatamappingVersion>1.1.0-alpha1</metadatamappingVersion>
+		<metadatamappingVersion>1.2.0-SNAPSHOT</metadatamappingVersion>
 		<uicommonsVersion>1.9</uicommonsVersion>
 		<appuiVersion>1.6</appuiVersion>
 		<htmlformentryVersion>3.1</htmlformentryVersion>


### PR DESCRIPTION
This PR refers to https://github.com/openmrs/openmrs-module-emrapi/pull/98