### PR TITLE
RA-1102 - Fixed reliability of AddDiagnosisToVisitNoteTest

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddDiagnosisToVisitNoteTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddDiagnosisToVisitNoteTest.java
@@ -25,7 +25,6 @@ public class AddDiagnosisToVisitNoteTest extends ReferenceApplicationTestBase {
     private VisitNotePage visitNotePage;
     
     @Test
-    @Ignore //unstable
     @Category(BuildTests.class)
     public void AddDiagnosisToVisitNoteTest() throws Exception {
     	
@@ -36,7 +35,7 @@ public class AddDiagnosisToVisitNoteTest extends ReferenceApplicationTestBase {
         assertEquals("Pneumonia", visitNotePage.primaryDiagnosis());
         assertEquals("Bleeding", visitNotePage.secondaryDiagnosis());
         visitNotePage.save();
-        assertNotNull(patientDashboardPage.visitLink());
+        visitNotePage.waitForElementWithSpecifiedMaxTimeout(ClinicianFacingPatientDashboardPage.VISIT_LINK, 30L);
         patientDashboardPage.endVisit();
 
     }


### PR DESCRIPTION
Issue was caused by waiting for toast notification element, because there are 15 seconds of maximum timeout by default.
I've just created method in openmrs-contrib-uitestframework that is able to set maximum timeout of waiting for specified element.

See this diagram for details:
![untitled diagram](https://cloud.githubusercontent.com/assets/17570611/17893937/cfef9864-6947-11e6-8511-b48544d49b67.png)
(Numbers indicates load time in seconds)

NOTE:
https://github.com/openmrs/openmrs-contrib-uitestframework/pull/8 needs to be merged before this one will work.