### PR TITLE
OCLM-50 - Add OCL module to Reference Application

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -257,6 +257,11 @@
 									<artifactId>reportingcompatibility-omod</artifactId>
 									<destFileName>reportingcompatibility-${reportingcompatibilityVersion}.omod</destFileName>
 								</artifactItem>
+								<artifactItem>
+									<groupId>org.openmrs.module</groupId>
+									<artifactId>openconceptlab-omod</artifactId>
+									<destFileName>openconceptlab-${openconceptlabVersion}.omod</destFileName>
+								</artifactItem>
 							</artifactItems>
 							<outputDirectory>${project.build.directory}/distro</outputDirectory>
 						</configuration>

--- a/package/src/main/resources/openmrs-distro.properties
+++ b/package/src/main/resources/openmrs-distro.properties
@@ -42,5 +42,6 @@ omod.adminui=${adminuiVersion}
 omod.reportingcompatibility=${reportingcompatibilityVersion}
 omod.legacyui=${legacyuiVersion}
 omod.owa=${owaVersion}
+omod.openconceptlab=${openconceptlabVersion}
 db.h2.supported=false
 db.sql=classpath://openmrs-distro.sql

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 		<reportingcompatibilityVersion>2.0.2</reportingcompatibilityVersion>
 		<fhirVersion>1.6</fhirVersion>
 		<owaVersion>1.6.3</owaVersion>
+		<openconceptlabVersion>1.2-SNAPSHOT</openconceptlabVersion> <!--TODO: SNAPSHOT VERSION, REMOVE AFTER RELEASE -->
 	</properties>
 
 	<dependencyManagement>
@@ -971,6 +972,16 @@
 				<artifactId>owa-omod</artifactId>
 				<version>${owaVersion}</version>
 				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>openconceptlab-omod</artifactId>
+				<version>${openconceptlabVersion}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>openconceptlab-api</artifactId>
+				<version>${openconceptlabVersion}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
This PR adds 1.2-SNAPSHOT version of OpenMRS OCL module to Refapp distro.
@rkorytkowski We should use 1.2 version here instead of SNAPSHOT, but we need to wait for release :)