### PR TITLE
Removing ignore annotation for tests Delete/Add/edit Allergy

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddNewAllergyTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddNewAllergyTest.java
@@ -37,7 +37,6 @@ public class AddNewAllergyTest extends ReferenceApplicationTestBase {
     }
 
     @Test
-    @Ignore("RA-1253")
     @Category(BuildTests.class)
     public void addNewAllergyTest() throws Exception {
         ActiveVisitsPage activeVisitsPage = homePage.goToActiveVisitsSearch();

--- a/ui-tests/src/test/java/org/openmrs/reference/DeleteAllergyTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/DeleteAllergyTest.java
@@ -38,7 +38,6 @@ public class DeleteAllergyTest extends ReferenceApplicationTestBase {
 
     @Test
     @Category(BuildTests.class)
-    @Ignore("RA-1253")
     public void deleteAllergyTest() throws Exception {
         ActiveVisitsPage activeVisitsPage = homePage.goToActiveVisitsSearch();
         activeVisitsPage.search(patient.identifier);

--- a/ui-tests/src/test/java/org/openmrs/reference/EditAllergyTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/EditAllergyTest.java
@@ -38,7 +38,6 @@ public class EditAllergyTest extends ReferenceApplicationTestBase {
     }
 
     @Test
-    @Ignore("RA-1253")
     @Category(BuildTests.class)
     public void editAllergyTest() throws Exception {
         ActiveVisitsPage activeVisitsPage = homePage.goToActiveVisitsSearch();


### PR DESCRIPTION
The tests  DeleteAllergyTest, AddNewAllergyTest and EditAllergyTest do not fail after fixing the bug
 [RA-1253](https://issues.openmrs.org/browse/RA-1253), therefore the ignore annotation has been removed from them