### PR TITLE
RA-1288: Changed weburl from int02 to qa-refapp

### DIFF
--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Remote server -->
-        <webapp.url>http://int02.openmrs.org/openmrs</webapp.url>
+        <webapp.url>http://qa-refapp.openmrs.org/openmrs</webapp.url>
         <!-- Local server -->
         <!--<webapp.url>http://localhost:8080/openmrs</webapp.url>-->
         <login.username>admin</login.username>


### PR DESCRIPTION
The variable weburl pointed to the old dismissed url int02, it has been updated to point to qa-refapp.