### PR TITLE
AddProviderTest enabled again

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddProviderTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddProviderTest.java
@@ -36,7 +36,6 @@ public class AddProviderTest extends ReferenceApplicationTestBase {
     }
 
     @Test
-    @Ignore("RA-1200")
     @Category(BuildTests.class)
     public void addProviderTest() throws InterruptedException {
         AdministrationPage administrationPage = homePage.goToAdministration();


### PR DESCRIPTION
According to[ comment ](https://issues.openmrs.org/browse/RA-1200)by the @dkayiwa, the test has been enabled again in order to evaluate if it keeps on failing