### PR TITLE
RA-1320: Tests for Manage Provider Schedule refactored and enabled

### DIFF
--- a/ui-tests/src/main/java/org/openmrs/reference/page/AppointmentBlocksPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/AppointmentBlocksPage.java
@@ -10,7 +10,6 @@
 
 package org.openmrs.reference.page;
 
-
 import java.util.List;
 
 import org.openmrs.uitestframework.page.Page;
@@ -19,173 +18,214 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class AppointmentBlocksPage extends Page {
-
-    private static final By APPOINTMENT_SCHEDULING = By.id("appointmentschedulingui-homeAppLink-appointmentschedulingui-homeAppLink-extension");
-    private static final By MANAGE_PROVIDER_SCHEDULES = By.id("appointmentschedulingui-scheduleProviders-app");
-    private static final By LOCATION = By.className("ng-pristine");
-    private static final By START_TIME = By.xpath("(//input[@type='text'])[5]");
-    private static final By SERVICE = By.id("createAppointmentBlock");
-    private static final By SERVICE_DROPDOWN = By.cssSelector("a.ng-scope.ng-binding");
-    private static final By EDIT_BLOCK= By.linkText("Edit");
-    private static final By SAVE = By.cssSelector("button.confirm");
-    private static final By PROVIDER = By.xpath("(//input[@type='text'])[3]");
-    //This identifier works if the calendar shows only the day 
-    private static final By SERVICE_TITLE_OF_THE_DAY = By.className("fc-event-title");
-    private	static final By DAY = By.xpath("/html/body/div/div[3]/div[2]/div[1]/div[2]/table/tbody/tr/td[1]/span[5]");
-    private static final By DAY_CLASS = By.className("fc-day-content");
-    public static final By CURRENT_DAY = By.className("fc-button fc-button-today fc-state-default fc-corner-left fc-corner-right fc-state-disabled");
-    private static final By LOCATION_IN_BLOCK = By.xpath("//div[@id='select-location']/select");
-    public static final By DELETE = By.linkText("Delete");
-    private static final By DELETE_CONFIRM = By.cssSelector("#delete-appointment-block-modal-buttons .confirm");
-    private static final By SERVICE_DELETE = By.xpath("//div[@id='appointment-block-form']/selectmultipleappointmenttypes/div/div/div/div/i");
-    private static final By CLOSE_WINDOW = By.cssSelector("#delete-appointment-block-modal > div.dialog-header > h3");
-    private static final By SERVICE_BLOCK = By.className("fc-event-inner");
-    private static final By DAY_BLOCK= By.xpath("//table[@class='fc-border-separate']/tbody/tr/td/div");
-    private static final By REMOVE_APPOINTMENT = By.xpath("//div[@id='appointment-block-form']/selectmultipleappointmenttypes/div/div/div/div/i");
-    private static final By CANCEL = By.className("cancel");
-    
-    public void goToAppointmentBlock(){
-        clickOn(APPOINTMENT_SCHEDULING);
-        clickOn(MANAGE_PROVIDER_SCHEDULES);
-    }
-
-    /**
-     * Removes an appointment.  
-     * Before calling this method is necessary to 
-     * click on the day (User should click on the day button on the left)
-     * @see #clickOnDay()
-     */
-    public void removeAppointment(){
-    	clickOn(REMOVE_APPOINTMENT);
-    }
-    public void selectLocation(String location) {
-    	// a wait might be needed if there are many elements to load in the dropdown menu
-        waiter.until(ExpectedConditions.elementToBeClickable(LOCATION));
-    	selectFrom(LOCATION, location);
-        clickOn(LOCATION);
-    }
-
-    public void selectLocationBlock(String locblock){
-        waitForElement(LOCATION_IN_BLOCK);
-        selectFrom(LOCATION_IN_BLOCK, locblock);
-        clickOn(LOCATION_IN_BLOCK);
-    }
-
-    public void enterService(String service){
-        boolean flag = false;
-        while(!flag) {
-            try {
-                findElement(SERVICE).clear();
-                setTextToFieldNoEnter(SERVICE, service);
-                waitForElement(SERVICE_DROPDOWN);
-                clickOn(SERVICE_DROPDOWN);
-                flag = true;
-            } catch(Exception e) {
-                flag = false;
-            }
-        }
-
-    }
-
-    public void enterProvider(String provider){setTextToFieldNoEnter(PROVIDER, provider);}
-
-    public void clickOnCurrentDay() throws InterruptedException{clickOn(CURRENT_DAY);}
-    public void enterStartTime(String start){setTextToFieldNoEnter(START_TIME, start);}
-
-    /**
-     * Scrolls the page up 
-     * This method has been created since the delete button 
-     * is hidden by the tooltip. 
-     * An alternative solution to this method is to create a method 
-     * that closes the tooltip such as:
-     * private static final By CLOSE_TOOLTIP = By.cssSelector("span.ui-icon.ui-icon-close");
-     * public void clickOnCloseTooltip(){
-     *	clickOn(CLOSE_TOOLTIP);
-     *	}
-     *Unfortunately this method did not prove to be always reliable (sometime Selenium fails to locate span.ui-icon.ui-icon-close) 
-     */
-    public void clickOnleft(){
-    	executeScript("scroll(300, 0)");
-    }
-    
-    /**
-     * Clicks on the current day and open the "editing page".
-     * This method should be invoked when the page shows only a block with the day
-     */
-    public void clickOnDay(){
-    	clickOn(DAY);
-    	clickOn(DAY_CLASS);
-    }
-    
-    /**
-     *Clicks on the Cancel button available in the "editing page" 
-     **/
-    public void clickOnCancel(){
-    	clickOn(CANCEL);
-    }
-        
-    public void clickOnSave(){
-        clickOn(SAVE);
-        try {
-            waitForElementToBeHidden(SAVE);
-        } catch(Exception e)
-        {
-
-        }
-    }
-    /**
-     *Checks if the the Save button available in the "editing page" is enabled 
-     */
-    public Boolean isSaveEnabled(){
-    	return findElement(SAVE).isEnabled();
-    }
-
-    public void clickOnDelete() throws InterruptedException{
-        waitForElement(DELETE);
-        clickOn(DELETE);
-    }
-    public void clickOnConfirmDelete(){clickOn(DELETE_CONFIRM);}
-    public void clickOnEdit(){clickOn(EDIT_BLOCK);}
-    public void clickOnServiceDelete(){clickOn(SERVICE_DELETE);}
-    public AppointmentBlocksPage(Page page) {super(page);}
-    
-    public void clickOnAppointment(){
-    	findElement(SERVICE_BLOCK).click();;
-    }
-    
-    /**
-     * Clicks on the Close button available in the "editing page"
-     */
-    public void clickOnClose(){
-        findElement(CLOSE_WINDOW);
-        clickOn(CLOSE_WINDOW);
-    }
-    
-    /**
-     * Extracts the service from a row displayed in the block
-     * 
-     * @param serviceChoice, the index of the service. For instance if there are 2 rows on the block, to get the first one serviceChoice = 0
-     * @return the Service in the row  (e.g. Dermatology)
-     */
-    public String getServiceOfDay(int serviceChoice){
-
-    		List<WebElement> elements = findElements(SERVICE_TITLE_OF_THE_DAY);
-	    	if(null != elements && elements.size() >= serviceChoice)
-	    	{
-	    		return elements.get(serviceChoice).getText();
-	    	}
-	    	else{
-	    		return new String();
-	    	}
-    }
-    
-    public void clickOnDayBlock(){
-    	clickOn(DAY_BLOCK);
-    }
-    
-    @Override
-    public String getPageUrl() {
-        return "/appointmentschedulingui/scheduleProviders.page";
-    }
+	
+	private static final By APPOINTMENT_SCHEDULING = By
+	        .id("appointmentschedulingui-homeAppLink-appointmentschedulingui-homeAppLink-extension");
+	
+	private static final By MANAGE_PROVIDER_SCHEDULES = By.id("appointmentschedulingui-scheduleProviders-app");
+	
+	private static final By LOCATION = By.className("ng-pristine");
+	
+	private static final By START_TIME = By.xpath("(//input[@type='text'])[5]");
+	
+	private static final By SERVICE = By.id("createAppointmentBlock");
+	
+	private static final By SERVICE_DROPDOWN = By.cssSelector("a.ng-scope.ng-binding");
+	
+	private static final By EDIT_BLOCK = By.linkText("Edit");
+	
+	private static final By SAVE = By.cssSelector("button.confirm");
+	
+	private static final By PROVIDER = By.xpath("(//input[@type='text'])[3]");
+	
+	//This identifier works if the calendar shows only the day 
+	private static final By SERVICE_TITLE_OF_THE_DAY = By.className("fc-event-title");
+	
+	private static final By DAY = By.xpath("/html/body/div/div[3]/div[2]/div[1]/div[2]/table/tbody/tr/td[1]/span[5]");
+	
+	private static final By DAY_CLASS = By.className("fc-day-content");
+	
+	public static final By CURRENT_DAY = By
+	        .className("fc-button fc-button-today fc-state-default fc-corner-left fc-corner-right fc-state-disabled");
+	
+	private static final By LOCATION_IN_BLOCK = By.xpath("//div[@id='select-location']/select");
+	
+	public static final By DELETE = By.linkText("Delete");
+	
+	private static final By DELETE_CONFIRM = By.cssSelector("#delete-appointment-block-modal-buttons .confirm");
+	
+	private static final By SERVICE_DELETE = By
+	        .xpath("//div[@id='appointment-block-form']/selectmultipleappointmenttypes/div/div/div/div/i");
+	
+	private static final By CLOSE_WINDOW = By.cssSelector("#delete-appointment-block-modal > div.dialog-header > h3");
+	
+	private static final By SERVICE_BLOCK = By.className("fc-event-inner");
+	
+	private static final By DAY_BLOCK = By.xpath("//table[@class='fc-border-separate']/tbody/tr/td/div");
+	
+	private static final By REMOVE_APPOINTMENT = By
+	        .xpath("//div[@id='appointment-block-form']/selectmultipleappointmenttypes/div/div/div/div/i");
+	
+	private static final By CANCEL = By.className("cancel");
+	
+	public void goToAppointmentBlock() {
+		clickOn(APPOINTMENT_SCHEDULING);
+		clickOn(MANAGE_PROVIDER_SCHEDULES);
+	}
+	
+	/**
+	 * Removes an appointment. Before calling this method is necessary to click on the day (User
+	 * should click on the day button on the left)
+	 * 
+	 * @see #clickOnDay()
+	 */
+	public void removeAppointment() {
+		clickOn(REMOVE_APPOINTMENT);
+	}
+	
+	public void selectLocation(String location) {
+		// a wait might be needed if there are many elements to load in the dropdown menu
+		waiter.until(ExpectedConditions.elementToBeClickable(LOCATION));
+		selectFrom(LOCATION, location);
+		clickOn(LOCATION);
+	}
+	
+	public void selectLocationBlock(String locblock) {
+		waitForElement(LOCATION_IN_BLOCK);
+		selectFrom(LOCATION_IN_BLOCK, locblock);
+		clickOn(LOCATION_IN_BLOCK);
+	}
+	
+	public void enterService(String service) {
+		boolean flag = false;
+		while (!flag) {
+			try {
+				findElement(SERVICE).clear();
+				setTextToFieldNoEnter(SERVICE, service);
+				waitForElement(SERVICE_DROPDOWN);
+				clickOn(SERVICE_DROPDOWN);
+				flag = true;
+			}
+			catch (Exception e) {
+				flag = false;
+			}
+		}
+		
+	}
+	
+	public void enterProvider(String provider) {
+		setTextToFieldNoEnter(PROVIDER, provider);
+	}
+	
+	public void clickOnCurrentDay() throws InterruptedException {
+		clickOn(CURRENT_DAY);
+	}
+	
+	public void enterStartTime(String start) {
+		setTextToFieldNoEnter(START_TIME, start);
+	}
+	
+	/**
+	 * Scrolls the page up This method has been created since the delete button is hidden by the
+	 * tooltip. An alternative solution to this method is to create a method that closes the tooltip
+	 * such as: private static final By CLOSE_TOOLTIP =
+	 * By.cssSelector("span.ui-icon.ui-icon-close"); public void clickOnCloseTooltip(){
+	 * clickOn(CLOSE_TOOLTIP); } Unfortunately this method did not prove to be always reliable
+	 * (sometime Selenium fails to locate span.ui-icon.ui-icon-close)
+	 */
+	public void clickOnleft() {
+		executeScript("scroll(300, 0)");
+	}
+	
+	/**
+	 * Clicks on the current day and open the "editing page". This method should be invoked when the
+	 * page shows only a block with the day
+	 */
+	public void clickOnDay() {
+		clickOn(DAY);
+		clickOn(DAY_CLASS);
+	}
+	
+	/**
+	 * Clicks on the Cancel button available in the "editing page"
+	 **/
+	public void clickOnCancel() {
+		clickOn(CANCEL);
+	}
+	
+	public void clickOnSave() {
+		clickOn(SAVE);
+		try {
+			waitForElementToBeHidden(SAVE);
+		}
+		catch (Exception e) {
+			
+		}
+	}
+	
+	/**
+	 * Checks if the the Save button available in the "editing page" is enabled
+	 */
+	public Boolean isSaveEnabled() {
+		return findElement(SAVE).isEnabled();
+	}
+	
+	public void clickOnDelete() throws InterruptedException {
+		waitForElement(DELETE);
+		clickOn(DELETE);
+	}
+	
+	public void clickOnConfirmDelete() {
+		clickOn(DELETE_CONFIRM);
+	}
+	
+	public void clickOnEdit() {
+		clickOn(EDIT_BLOCK);
+	}
+	
+	public void clickOnServiceDelete() {
+		clickOn(SERVICE_DELETE);
+	}
+	
+	public AppointmentBlocksPage(Page page) {
+		super(page);
+	}
+	
+	public void clickOnAppointment() {
+		findElement(SERVICE_BLOCK).click();
+		;
+	}
+	
+	/**
+	 * Clicks on the Close button available in the "editing page"
+	 */
+	public void clickOnClose() {
+		findElement(CLOSE_WINDOW);
+		clickOn(CLOSE_WINDOW);
+	}
+	
+	/**
+	 * Extracts the service from a row displayed in the block
+	 * 
+	 * @param serviceChoice, the index of the service. For instance if there are 2 rows on the
+	 *            block, to get the first one serviceChoice = 0
+	 * @return the Service in the row (e.g. Dermatology)
+	 */
+	public String getServiceOfDay(int serviceChoice) {
+		
+		List<WebElement> elements = findElements(SERVICE_TITLE_OF_THE_DAY);
+		if (null != elements && elements.size() >= serviceChoice) {
+			return elements.get(serviceChoice).getText();
+		} 
+		return new String();
+	}
+	
+	public void clickOnDayBlock() {
+		clickOn(DAY_BLOCK);
+	}
+	
+	@Override
+	public String getPageUrl() {
+		return "/appointmentschedulingui/scheduleProviders.page";
+	}
 }
-

--- a/ui-tests/src/main/java/org/openmrs/reference/page/AppointmentBlocksPage.java
+++ b/ui-tests/src/main/java/org/openmrs/reference/page/AppointmentBlocksPage.java
@@ -10,9 +10,13 @@
 
 package org.openmrs.reference.page;
 
+
+import java.util.List;
+
 import org.openmrs.uitestframework.page.Page;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class AppointmentBlocksPage extends Page {
 
@@ -21,25 +25,43 @@ public class AppointmentBlocksPage extends Page {
     private static final By LOCATION = By.className("ng-pristine");
     private static final By START_TIME = By.xpath("(//input[@type='text'])[5]");
     private static final By SERVICE = By.id("createAppointmentBlock");
-    private static final By BLOCK = By.className("fc-event-title");
     private static final By SERVICE_DROPDOWN = By.cssSelector("a.ng-scope.ng-binding");
     private static final By EDIT_BLOCK= By.linkText("Edit");
     private static final By SAVE = By.cssSelector("button.confirm");
     private static final By PROVIDER = By.xpath("(//input[@type='text'])[3]");
-    public static final By CURRENT_DAY = By.className("fc-state-highlight");
+    //This identifier works if the calendar shows only the day 
+    private static final By SERVICE_TITLE_OF_THE_DAY = By.className("fc-event-title");
+    private	static final By DAY = By.xpath("/html/body/div/div[3]/div[2]/div[1]/div[2]/table/tbody/tr/td[1]/span[5]");
+    private static final By DAY_CLASS = By.className("fc-day-content");
+    public static final By CURRENT_DAY = By.className("fc-button fc-button-today fc-state-default fc-corner-left fc-corner-right fc-state-disabled");
     private static final By LOCATION_IN_BLOCK = By.xpath("//div[@id='select-location']/select");
     public static final By DELETE = By.linkText("Delete");
     private static final By DELETE_CONFIRM = By.cssSelector("#delete-appointment-block-modal-buttons .confirm");
     private static final By SERVICE_DELETE = By.xpath("//div[@id='appointment-block-form']/selectmultipleappointmenttypes/div/div/div/div/i");
     private static final By CLOSE_WINDOW = By.cssSelector("#delete-appointment-block-modal > div.dialog-header > h3");
-    private static final By COUNT_BLOCK = By.xpath("//div[@id='calendar']/div/div/div/div");
+    private static final By SERVICE_BLOCK = By.className("fc-event-inner");
+    private static final By DAY_BLOCK= By.xpath("//table[@class='fc-border-separate']/tbody/tr/td/div");
+    private static final By REMOVE_APPOINTMENT = By.xpath("//div[@id='appointment-block-form']/selectmultipleappointmenttypes/div/div/div/div/i");
+    private static final By CANCEL = By.className("cancel");
+    
     public void goToAppointmentBlock(){
         clickOn(APPOINTMENT_SCHEDULING);
         clickOn(MANAGE_PROVIDER_SCHEDULES);
     }
 
+    /**
+     * Removes an appointment.  
+     * Before calling this method is necessary to 
+     * click on the day (User should click on the day button on the left)
+     * @see #clickOnDay()
+     */
+    public void removeAppointment(){
+    	clickOn(REMOVE_APPOINTMENT);
+    }
     public void selectLocation(String location) {
-        selectFrom(LOCATION, location);
+    	// a wait might be needed if there are many elements to load in the dropdown menu
+        waiter.until(ExpectedConditions.elementToBeClickable(LOCATION));
+    	selectFrom(LOCATION, location);
         clickOn(LOCATION);
     }
 
@@ -70,6 +92,38 @@ public class AppointmentBlocksPage extends Page {
     public void clickOnCurrentDay() throws InterruptedException{clickOn(CURRENT_DAY);}
     public void enterStartTime(String start){setTextToFieldNoEnter(START_TIME, start);}
 
+    /**
+     * Scrolls the page up 
+     * This method has been created since the delete button 
+     * is hidden by the tooltip. 
+     * An alternative solution to this method is to create a method 
+     * that closes the tooltip such as:
+     * private static final By CLOSE_TOOLTIP = By.cssSelector("span.ui-icon.ui-icon-close");
+     * public void clickOnCloseTooltip(){
+     *	clickOn(CLOSE_TOOLTIP);
+     *	}
+     *Unfortunately this method did not prove to be always reliable (sometime Selenium fails to locate span.ui-icon.ui-icon-close) 
+     */
+    public void clickOnleft(){
+    	executeScript("scroll(300, 0)");
+    }
+    
+    /**
+     * Clicks on the current day and open the "editing page".
+     * This method should be invoked when the page shows only a block with the day
+     */
+    public void clickOnDay(){
+    	clickOn(DAY);
+    	clickOn(DAY_CLASS);
+    }
+    
+    /**
+     *Clicks on the Cancel button available in the "editing page" 
+     **/
+    public void clickOnCancel(){
+    	clickOn(CANCEL);
+    }
+        
     public void clickOnSave(){
         clickOn(SAVE);
         try {
@@ -78,6 +132,12 @@ public class AppointmentBlocksPage extends Page {
         {
 
         }
+    }
+    /**
+     *Checks if the the Save button available in the "editing page" is enabled 
+     */
+    public Boolean isSaveEnabled(){
+    	return findElement(SAVE).isEnabled();
     }
 
     public void clickOnDelete() throws InterruptedException{
@@ -88,24 +148,41 @@ public class AppointmentBlocksPage extends Page {
     public void clickOnEdit(){clickOn(EDIT_BLOCK);}
     public void clickOnServiceDelete(){clickOn(SERVICE_DELETE);}
     public AppointmentBlocksPage(Page page) {super(page);}
-
-
-    public void findBlock() {
-
-        try {
-            findElement(By.xpath("//div[@id='calendar']/div/div/div/div[" + driver.findElements(COUNT_BLOCK).size() + "]/div/span[2]")).click();
-        } catch (Exception e) {
-
-        }
+    
+    public void clickOnAppointment(){
+    	findElement(SERVICE_BLOCK).click();;
     }
+    
+    /**
+     * Clicks on the Close button available in the "editing page"
+     */
     public void clickOnClose(){
         findElement(CLOSE_WINDOW);
         clickOn(CLOSE_WINDOW);
     }
+    
+    /**
+     * Extracts the service from a row displayed in the block
+     * 
+     * @param serviceChoice, the index of the service. For instance if there are 2 rows on the block, to get the first one serviceChoice = 0
+     * @return the Service in the row  (e.g. Dermatology)
+     */
+    public String getServiceOfDay(int serviceChoice){
 
-
-
-
+    		List<WebElement> elements = findElements(SERVICE_TITLE_OF_THE_DAY);
+	    	if(null != elements && elements.size() >= serviceChoice)
+	    	{
+	    		return elements.get(serviceChoice).getText();
+	    	}
+	    	else{
+	    		return new String();
+	    	}
+    }
+    
+    public void clickOnDayBlock(){
+    	clickOn(DAY_BLOCK);
+    }
+    
     @Override
     public String getPageUrl() {
         return "/appointmentschedulingui/scheduleProviders.page";

--- a/ui-tests/src/test/java/org/openmrs/reference/AddEditAppointmentBlockTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddEditAppointmentBlockTest.java
@@ -17,61 +17,65 @@ import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
 import static org.junit.Assert.assertTrue;
 
-
 public class AddEditAppointmentBlockTest extends ManageProviderSchedulesTest {
 	
-	
 	private final String startTimeFirstAppointment = "09";
+	
 	private String firstAppointment = "Gynecology";
-    private String secondAppointment = "Dermatology";
-    int firstAppointmentIndex = 0;
-    int secondAppointmentIndex = 1; 
+	
+	private String secondAppointment = "Dermatology";
+	
+	int firstAppointmentIndex = 0;
+	
+	int secondAppointmentIndex = 1;
 	
 	@Before
-    public void setUp() throws Exception {
-    	super.setUp();
+	public void setUp() throws Exception {
+		super.setUp();
 	}
-
-    @Test
-    @Category(BuildTests.class)
-    public void editAppointmentBlockTest() throws Exception {
-        
-        /*
-         * The logic behind the text is:
-         * create an appointment and assert that exists 
-         * change the service and assert that it has been changed
-         * search the newly created service
-         * delete the appointment
-    	*/
-    	appointmentBlocksPage.selectLocation(locationName);
-        appointmentBlocksPage.clickOnDay();
-        appointmentBlocksPage.enterStartTime(startTimeFirstAppointment);
-        appointmentBlocksPage.enterService("gyne");
-        appointmentBlocksPage.enterProvider(provider);
-        appointmentBlocksPage.clickOnSave();
-        assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(firstAppointment));
-        appointmentBlocksPage.clickOnAppointment();
-        appointmentBlocksPage.clickOnEdit();
-        appointmentBlocksPage.removeAppointment();
-        appointmentBlocksPage.enterService("derma");
-        appointmentBlocksPage.clickOnSave();
-        assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(secondAppointment));
-        appointmentBlocksPage.goToPage(appointmentBlocksPage.getPageUrl());
-        appointmentBlocksPage.selectLocation(locationName);
-        appointmentBlocksPage.clickOnDay();
-        //let's check that also the Cancel button works 
-        appointmentBlocksPage.clickOnCancel();
-        appointmentBlocksPage.clickOnAppointment();
-        appointmentBlocksPage.clickOnDelete();
-        //click on "left area" is needed because the tooltip shadows the delete button
-        appointmentBlocksPage.clickOnleft();
-        appointmentBlocksPage.clickOnConfirmDelete();
-    }
-    
-    @After
-    public void tearDown() throws Exception {
-    	super.tearDown();
-    }
-
+	
+	/*
+	 *@verifies the creation and editing of an appointment  
+	 */
+	@Test
+	@Category(BuildTests.class)
+	public void editAppointmentBlockTest() throws Exception {
+		
+		/*
+		 * The logic behind the text is:
+		 * create an appointment and assert that exists 
+		 * change the service and assert that it has been changed
+		 * search the newly created service
+		 * delete the appointment
+		*/
+		appointmentBlocksPage.selectLocation(locationName);
+		appointmentBlocksPage.clickOnDay();
+		appointmentBlocksPage.enterStartTime(startTimeFirstAppointment);
+		appointmentBlocksPage.enterService("gyne");
+		appointmentBlocksPage.enterProvider(provider);
+		appointmentBlocksPage.clickOnSave();
+		assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(firstAppointment));
+		appointmentBlocksPage.clickOnAppointment();
+		appointmentBlocksPage.clickOnEdit();
+		appointmentBlocksPage.removeAppointment();
+		appointmentBlocksPage.enterService("derma");
+		appointmentBlocksPage.clickOnSave();
+		assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(secondAppointment));
+		appointmentBlocksPage.goToPage(appointmentBlocksPage.getPageUrl());
+		appointmentBlocksPage.selectLocation(locationName);
+		appointmentBlocksPage.clickOnDay();
+		//let's check that also the Cancel button works 
+		appointmentBlocksPage.clickOnCancel();
+		appointmentBlocksPage.clickOnAppointment();
+		appointmentBlocksPage.clickOnDelete();
+		//click on "left area" is needed because the tooltip shadows the delete button
+		appointmentBlocksPage.clickOnleft();
+		appointmentBlocksPage.clickOnConfirmDelete();
+	}
+	
+	@After
+	public void tearDown() throws Exception {
+		super.tearDown();
+	}
+	
 }
-

--- a/ui-tests/src/test/java/org/openmrs/reference/AddEditAppointmentBlockTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddEditAppointmentBlockTest.java
@@ -12,46 +12,66 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
-import org.openmrs.reference.page.*;
-import org.openmrs.uitestframework.test.TestBase;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 
-public class AddEditAppointmentBlockTest extends ReferenceApplicationTestBase {
+public class AddEditAppointmentBlockTest extends ManageProviderSchedulesTest {
+	
+	
+	private final String startTimeFirstAppointment = "09";
+	private String firstAppointment = "Gynecology";
+    private String secondAppointment = "Dermatology";
+    int firstAppointmentIndex = 0;
+    int secondAppointmentIndex = 1; 
+	
+	@Before
+    public void setUp() throws Exception {
+    	super.setUp();
+	}
 
     @Test
-    @Ignore
     @Category(BuildTests.class)
     public void editAppointmentBlockTest() throws Exception {
-        AppointmentSchedulingPage appointmentSchedulingPage = homePage.goToAppointmentScheduling();
-        AppointmentBlocksPage appointmentBlocksPage = appointmentSchedulingPage.goToAppointmentBlock();
-
-        appointmentBlocksPage.selectLocation("Outpatient Clinic");
-        appointmentBlocksPage.clickOnCurrentDay();
-        appointmentBlocksPage.selectLocationBlock("Outpatient Clinic");
-        appointmentBlocksPage.enterService("derm");
+        
+        /*
+         * The logic behind the text is:
+         * create an appointment and assert that exists 
+         * change the service and assert that it has been changed
+         * search the newly created service
+         * delete the appointment
+    	*/
+    	appointmentBlocksPage.selectLocation(locationName);
+        appointmentBlocksPage.clickOnDay();
+        appointmentBlocksPage.enterStartTime(startTimeFirstAppointment);
+        appointmentBlocksPage.enterService("gyne");
+        appointmentBlocksPage.enterProvider(provider);
         appointmentBlocksPage.clickOnSave();
-
-        assertNotNull("Dermatology", appointmentBlocksPage.CURRENT_DAY);
-
-        appointmentBlocksPage.findBlock();
+        assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(firstAppointment));
+        appointmentBlocksPage.clickOnAppointment();
         appointmentBlocksPage.clickOnEdit();
-        appointmentBlocksPage.enterProvider("Jake Smith");
-        appointmentBlocksPage.clickOnServiceDelete();
-        appointmentBlocksPage.enterService("onco");
+        appointmentBlocksPage.removeAppointment();
+        appointmentBlocksPage.enterService("derma");
         appointmentBlocksPage.clickOnSave();
-
-        assertNotNull("Oncology", appointmentBlocksPage.CURRENT_DAY);
-
-        appointmentBlocksPage.findBlock();
+        assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(secondAppointment));
+        appointmentBlocksPage.goToPage(appointmentBlocksPage.getPageUrl());
+        appointmentBlocksPage.selectLocation(locationName);
+        appointmentBlocksPage.clickOnDay();
+        //let's check that also the Cancel button works 
+        appointmentBlocksPage.clickOnCancel();
+        appointmentBlocksPage.clickOnAppointment();
         appointmentBlocksPage.clickOnDelete();
-        appointmentBlocksPage.clickOnClose();
+        //click on "left area" is needed because the tooltip shadows the delete button
+        appointmentBlocksPage.clickOnleft();
         appointmentBlocksPage.clickOnConfirmDelete();
     }
+    
+    @After
+    public void tearDown() throws Exception {
+    	super.tearDown();
+    }
+
 }
 

--- a/ui-tests/src/test/java/org/openmrs/reference/DeleteAppointmentBlockTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/DeleteAppointmentBlockTest.java
@@ -8,7 +8,6 @@
  * graphic logo is a trademark of OpenMRS Inc.
  */
 
-
 package org.openmrs.reference;
 
 import org.junit.After;
@@ -17,44 +16,49 @@ import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 
 public class DeleteAppointmentBlockTest extends ManageProviderSchedulesTest {
-    
-	private String correctStartTimeFirtAppointment = "08";
-    private String outboundStartTime = "30";
-    private String firstAppointment = "Gynecology";
-    int firstAppointmentIndex = 0;
-    
-    
-    @Before
-    public void setUp() throws Exception {
-    	super.setUp();
-    }
 	
-    @Test
-    public void deleteAppointmentBlockTest() throws Exception {
-    	
-    	//The logic behind the text is to create an appointment and delete it
-    	appointmentBlocksPage.selectLocation(locationName);
-        appointmentBlocksPage.clickOnDay();
-        /*
-         * Here we make negative test: using outbound values for start time should result
-         * that Save button is disabled 
-         */
-        appointmentBlocksPage.enterStartTime(outboundStartTime);
-        assertTrue(!appointmentBlocksPage.isSaveEnabled());
-        appointmentBlocksPage.enterStartTime(correctStartTimeFirtAppointment);
-        appointmentBlocksPage.enterService("gyne");
-        appointmentBlocksPage.enterProvider(provider);
-        appointmentBlocksPage.clickOnSave();
-        assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(firstAppointment));
-        //let'remove the appointment
-        appointmentBlocksPage.clickOnAppointment();
-        appointmentBlocksPage.clickOnDelete();
-        appointmentBlocksPage.clickOnleft();
-        appointmentBlocksPage.clickOnConfirmDelete();
-    }
-    @After
-    public void tearDown() throws Exception {
-    	super.tearDown();
-    }
+	private String correctStartTimeFirtAppointment = "08";
+	
+	private String outboundStartTime = "30";
+	
+	private String firstAppointment = "Gynecology";
+	
+	int firstAppointmentIndex = 0;
+	
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+	}
+	
+	/*
+	 * @verifies creation and delete of an appointment
+	 */
+	@Test
+	public void deleteAppointmentBlockTest() throws Exception {
+		
+		//The logic behind the text is to create an appointment and delete it
+		appointmentBlocksPage.selectLocation(locationName);
+		appointmentBlocksPage.clickOnDay();
+		/*
+		 * Here we make negative test: using outbound values for start time should result
+		 * that Save button is disabled 
+		 */
+		appointmentBlocksPage.enterStartTime(outboundStartTime);
+		assertTrue(!appointmentBlocksPage.isSaveEnabled());
+		appointmentBlocksPage.enterStartTime(correctStartTimeFirtAppointment);
+		appointmentBlocksPage.enterService("gyne");
+		appointmentBlocksPage.enterProvider(provider);
+		appointmentBlocksPage.clickOnSave();
+		assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(firstAppointment));
+		//let'remove the appointment
+		appointmentBlocksPage.clickOnAppointment();
+		appointmentBlocksPage.clickOnDelete();
+		appointmentBlocksPage.clickOnleft();
+		appointmentBlocksPage.clickOnConfirmDelete();
+	}
+	
+	@After
+	public void tearDown() throws Exception {
+		super.tearDown();
+	}
 }
-

--- a/ui-tests/src/test/java/org/openmrs/reference/DeleteAppointmentBlockTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/DeleteAppointmentBlockTest.java
@@ -1,53 +1,60 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 
 
 package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.openmrs.reference.page.*;
-import org.openmrs.uitestframework.test.TestBase;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-
-/**
- * Created by nata on 08.07.2015.
- */
-public class DeleteAppointmentBlockTest extends TestBase {
-    private HomePage homePage;
-    private HeaderPage headerPage;
-    private AppointmentBlocksPage appointmentBlocksPage;
-
+public class DeleteAppointmentBlockTest extends ManageProviderSchedulesTest {
+    
+	private String correctStartTimeFirtAppointment = "08";
+    private String outboundStartTime = "30";
+    private String firstAppointment = "Gynecology";
+    int firstAppointmentIndex = 0;
+    
+    
     @Before
     public void setUp() throws Exception {
-        
-        homePage = new HomePage(page);
-        assertPage(homePage);
-        headerPage = new HeaderPage(driver);
-        appointmentBlocksPage = new AppointmentBlocksPage(page);
+    	super.setUp();
     }
-
-    @Ignore//ignored due to possible application logout
+	
     @Test
     public void deleteAppointmentBlockTest() throws Exception {
-        appointmentBlocksPage.goToAppointmentBlock();
-        appointmentBlocksPage.selectLocation("Outpatient Clinic");
-        appointmentBlocksPage.clickOnCurrentDay();
-        appointmentBlocksPage.selectLocationBlock("Outpatient Clinic");
-        appointmentBlocksPage.enterService("derm");
-        appointmentBlocksPage.enterProvider("Super User");
+    	
+    	//The logic behind the text is to create an appointment and delete it
+    	appointmentBlocksPage.selectLocation(locationName);
+        appointmentBlocksPage.clickOnDay();
+        /*
+         * Here we make negative test: using outbound values for start time should result
+         * that Save button is disabled 
+         */
+        appointmentBlocksPage.enterStartTime(outboundStartTime);
+        assertTrue(!appointmentBlocksPage.isSaveEnabled());
+        appointmentBlocksPage.enterStartTime(correctStartTimeFirtAppointment);
+        appointmentBlocksPage.enterService("gyne");
+        appointmentBlocksPage.enterProvider(provider);
         appointmentBlocksPage.clickOnSave();
-        assertNotNull("Dermatology", appointmentBlocksPage.CURRENT_DAY);
-        appointmentBlocksPage.findBlock();
+        assertTrue(appointmentBlocksPage.getServiceOfDay(firstAppointmentIndex).equals(firstAppointment));
+        //let'remove the appointment
+        appointmentBlocksPage.clickOnAppointment();
         appointmentBlocksPage.clickOnDelete();
-        appointmentBlocksPage.clickOnClose();
+        appointmentBlocksPage.clickOnleft();
         appointmentBlocksPage.clickOnConfirmDelete();
     }
     @After
     public void tearDown() throws Exception {
-        headerPage.clickOnHomeIcon();
-        headerPage.logOut();
+    	super.tearDown();
     }
 }
 

--- a/ui-tests/src/test/java/org/openmrs/reference/ManageProviderSchedulesTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/ManageProviderSchedulesTest.java
@@ -12,50 +12,53 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.openmrs.reference.page.*;
+import org.openmrs.reference.page.HomePage;
+import org.openmrs.reference.page.AppointmentBlocksPage;
+import org.openmrs.reference.page.AppointmentSchedulingPage;
 import org.openmrs.uitestframework.test.TestData;
-import static org.junit.Assert.assertNotNull;
 
 /**
- * This class is meant to create the preconditions (set-up)
- * and to clean up the environment (tear down) after the tests 
- * AddEditAppointmbetBlockTest and DeleteAppointmentBlocktTest 
- * have been executed.
- * Subclassing ManageProviderSchedulsTest is a possible solution
- * for a common set-up. Other possibilities are Rules or extending TestSetup.
- * The latter possibilities might be applied in future 
- * if the test code become hard to maintain/read
+ * This class is meant to create the preconditions (set-up) and to clean up the environment (tear
+ * down) after the tests AddEditAppointmbetBlockTest and DeleteAppointmentBlocktTest have been
+ * executed. Subclassing ManageProviderSchedulsTest is a possible solution for a common set-up.
+ * Other possibilities are Rules or extending TestSetup. The latter possibilities might be applied
+ * in future if the test code become hard to maintain/read
  */
 public class ManageProviderSchedulesTest extends ReferenceApplicationTestBase {
-    protected HomePage homePage;
-    protected AppointmentBlocksPage appointmentBlocksPage;
-    protected String locationName;
-    protected String locationUuid;
-    protected String provider;
-    
-    @Before
-    public void setUp() throws Exception {
-        homePage = new HomePage(page);
-        assertPage(homePage);
-        AppointmentSchedulingPage appointmentSchedulingPage = homePage.goToAppointmentScheduling();
-        appointmentBlocksPage = appointmentSchedulingPage.goToAppointmentBlock();
-        /*
-         * The following code should be renabled as soon as it is possible to delete location successfully via rest 
-         * Location might not be available when running this test, thus we create one
-         * locationName = "Location-"+TestData.randomSuffix();
-         * We must be sure that the location has been created, the test will fail otherwise
-         * locationUuid = TestData.createLocation(locationName);
-         * assertNotNull(locationUuid);
-        */
-        locationName = "Isolation Ward";
-        provider = "Provider "+TestData.randomSuffix();
-    }
-    @After
-    public void tearDown() throws Exception {
-    	/*
-    	 *  TODO delete the location. Currently,the following method is not able to delete the location.
-    	 * TestData.permanetDelete(locationUuid);  
-    	 */
-    }
+	
+	protected HomePage homePage;
+	
+	protected AppointmentBlocksPage appointmentBlocksPage;
+	
+	protected String locationName;
+	
+	protected String locationUuid;
+	
+	protected String provider;
+	
+	@Before
+	public void setUp() throws Exception {
+		homePage = new HomePage(page);
+		assertPage(homePage);
+		AppointmentSchedulingPage appointmentSchedulingPage = homePage.goToAppointmentScheduling();
+		appointmentBlocksPage = appointmentSchedulingPage.goToAppointmentBlock();
+		/*
+		 * TODO The following code should be re-nabled when bug AM-186 is fixed
+		 * Location might not be available when running this test, thus we create one
+		 * locationName = "Location-"+TestData.randomSuffix();
+		 * We must be sure that the location has been created, the test will fail otherwise
+		 * locationUuid = TestData.createLocation(locationName);
+		 * assertNotNull(locationUuid);
+		*/
+		locationName = "Isolation Ward";
+		provider = "Provider " + TestData.randomSuffix();
+	}
+	
+	@After
+	public void tearDown() throws Exception {
+		/*
+		 *  TODO delete the location. Re-enable when bug AM-186 is fixed.
+		 * TestData.permanetDelete(locationUuid);  
+		 */
+	}
 }
-

--- a/ui-tests/src/test/java/org/openmrs/reference/ManageProviderSchedulesTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/ManageProviderSchedulesTest.java
@@ -1,59 +1,61 @@
-
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 
 package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.openmrs.reference.page.*;
-import org.openmrs.uitestframework.test.TestBase;
+import org.openmrs.uitestframework.test.TestData;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 
 /**
- * Created by nata on 17.07.2015.
+ * This class is meant to create the preconditions (set-up)
+ * and to clean up the environment (tear down) after the tests 
+ * AddEditAppointmbetBlockTest and DeleteAppointmentBlocktTest 
+ * have been executed.
+ * Subclassing ManageProviderSchedulsTest is a possible solution
+ * for a common set-up. Other possibilities are Rules or extending TestSetup.
+ * The latter possibilities might be applied in future 
+ * if the test code become hard to maintain/read
  */
-public class ManageProviderSchedulesTest extends TestBase {
-    private HomePage homePage;
-    private HeaderPage headerPage;
-    private AppointmentBlocksPage appointmentBlocksPage;
-
+public class ManageProviderSchedulesTest extends ReferenceApplicationTestBase {
+    protected HomePage homePage;
+    protected AppointmentBlocksPage appointmentBlocksPage;
+    protected String locationName;
+    protected String locationUuid;
+    protected String provider;
+    
     @Before
     public void setUp() throws Exception {
-        
         homePage = new HomePage(page);
         assertPage(homePage);
-        headerPage = new HeaderPage(driver);
-        appointmentBlocksPage = new AppointmentBlocksPage(page);
+        AppointmentSchedulingPage appointmentSchedulingPage = homePage.goToAppointmentScheduling();
+        appointmentBlocksPage = appointmentSchedulingPage.goToAppointmentBlock();
+        /*
+         * The following code should be renabled as soon as it is possible to delete location successfully via rest 
+         * Location might not be available when running this test, thus we create one
+         * locationName = "Location-"+TestData.randomSuffix();
+         * We must be sure that the location has been created, the test will fail otherwise
+         * locationUuid = TestData.createLocation(locationName);
+         * assertNotNull(locationUuid);
+        */
+        locationName = "Isolation Ward";
+        provider = "Provider "+TestData.randomSuffix();
     }
-
-    @Ignore //ignored due to RA-904
-    @Test
-    public void manageProviderSchedulesTest() throws Exception {
-        appointmentBlocksPage.goToAppointmentBlock();
-        appointmentBlocksPage.selectLocation("Isolation Ward");
-        appointmentBlocksPage.clickOnCurrentDay();
-        appointmentBlocksPage.selectLocationBlock("Isolation Ward");
-        appointmentBlocksPage.enterStartTime("08");
-        appointmentBlocksPage.enterService("gyne");
-        appointmentBlocksPage.enterProvider("Super User");
-        appointmentBlocksPage.clickOnSave();
-        assertNotNull("Gynecology", appointmentBlocksPage.CURRENT_DAY);
-        appointmentBlocksPage.findBlock();
-        appointmentBlocksPage.clickOnEdit();
-        appointmentBlocksPage.enterService("derma");
-        appointmentBlocksPage.clickOnSave();
-        assertNotNull("Dermatology", appointmentBlocksPage.CURRENT_DAY);
-        appointmentBlocksPage.findBlock();
-        appointmentBlocksPage.clickOnDelete();
-        appointmentBlocksPage.clickOnConfirmDelete();}
-
     @After
     public void tearDown() throws Exception {
-        headerPage.clickOnHomeIcon();
-        headerPage.logOut();
+    	/*
+    	 *  TODO delete the location. Currently,the following method is not able to delete the location.
+    	 * TestData.permanetDelete(locationUuid);  
+    	 */
     }
 }
 


### PR DESCRIPTION
According to bug RA-1320 the tests AddEditAppointmentBlockTest.java, DeleteAppointmentBlockTest and ManageProviderSchedulesTest failed. Additionally they share partially the same code. Hence, tests have been refactored. ManageProviderSchedulesTest is the father class  of AddEdit and Delete and set up/tear down the test. 
