### PR TITLE
RA-1348: updated reference to the integration server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Please follow the instructions at the [OpenMRS SDK Wiki page](https://wiki.openm
 ### Running ui-tests locally:
 
 By default tests are run with Firefox 42.0 ([download here](https://ftp.mozilla.org/pub/firefox/releases/42.0/)), so please be sure to have it installed.
-Also tests are run against http://int02.openmrs.org/openmrs so confirm it is accessible from your machine.
-It is also possible that tests start failing due to int02.openmrs.org being redeployed. If it happens, please wait for int02 to be available again and run tests again.
+Also tests are run against https://qa-refapp.openmrs.org so confirm it is accessible from your machine.
+It is also possible that tests start failing due to qa-refapp being redeployed. If it happens, please wait for qa-refapp to be available again and run tests again.
 
 1. Clone the repo
 2. Go to the ui-tests directory using command line
-3. Run `mvn clean install -Prun-all-tests`
+3. Run `mvn clean install`
 
 ### Running ui-tests on Travis CI with SauceLabs
 
@@ -42,7 +42,7 @@ To setup Continuous Integration on your fork, execute following steps:
 
 And that's it!
 
-If you would like to setup a similar configuraiton for your distribution, please have a look at [.travis.yml](https://github.com/openmrs/openmrs-distro-referenceapplication/blob/master/.travis.yml). The test server is created using `openmrs-sdk:build-distro` and started with `docker-compose up` on Travis-CI. 
+If you would like to setup a similar configuration for your distribution, please have a look at [.travis.yml](https://github.com/openmrs/openmrs-distro-referenceapplication/blob/master/.travis.yml). The test server is created using `openmrs-sdk:build-distro` and started with `docker-compose up` on Travis-CI. 
 
 Travis-CI creates a tunnel to SauceLabs, which allows SauceLabs to access the test server and execute tests against that server in a browser. In order to speed up the build, we always run 5 UI tests in parallel using agents provided by SauceLabs. The test server is automatically terminated by Travis-CI once tests are done. 
 
@@ -51,3 +51,7 @@ Travis-CI creates a tunnel to SauceLabs, which allows SauceLabs to access the te
 
 As of March 2017, the resources for this method are outdated/ no longer maintained. 
 https://wiki.openmrs.org/x/CIC3Ag
+
+## Writing test cases 
+
+While writing the code for the test cases, please, follow the instructions in the [Code Style paragraph](https://wiki.openmrs.org/display/docs/Java+Conventions) and the [guidelines](https://wiki.openmrs.org/display/docs/Automated+Testing+Guidelines) 


### PR DESCRIPTION
The reference in the readme.md to the integration server was erroneous because refereed to the old name of the server (int02).
Additionally the flag -Prun test didn't work anymore.