### PR TITLE
RA-1351: Update of weburl to https

### DIFF
--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Remote server -->
-        <webapp.url>http://qa-refapp.openmrs.org/openmrs</webapp.url>
+        <webapp.url>https://qa-refapp.openmrs.org/openmrs</webapp.url>
         <!-- Local server -->
         <!--<webapp.url>http://localhost:8080/openmrs</webapp.url>-->
         <login.username>admin</login.username>


### PR DESCRIPTION
The weburl http:qa-refapp ... caused the rest API to fail locally, updated to https:qa-refapp...