### PR TITLE
RA-1193: Test on July failed, tryed to re-enable it 

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddPastVisitTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddPastVisitTest.java
@@ -11,7 +11,6 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
@@ -34,7 +33,6 @@ public class AddPastVisitTest extends LocationSensitiveApplicationTestBase {
     }
 
     @Test
-    @Ignore
     @Category(BuildTests.class)
     public void addPastVisitTest() throws Exception {
         FindPatientPage findPatientPage = homePage.goToFindPatientRecord();


### PR DESCRIPTION
According to the [topic]((only the  ignore annotation has been removed)) , we have to re-enable this test and investigate whenever it fails on SauceLab
