### PR TITLE
 Please Revert OpenMRS Distro from 2.8.0-SNAPSHOT to 2.7.0-SNAPSHOT 

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.distro</groupId>
 	<artifactId>referenceapplication-package</artifactId>
-	<version>2.8.0-SNAPSHOT</version>
+	<version>2.7.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Reference Application Distribution Package</name>
 	<description>Reference Application Distribution Package</description>
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.openmrs.distro</groupId>
 		<artifactId>referenceapplication</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.7.0-SNAPSHOT</version>
 	</parent>
 
 	<organization>

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -12,7 +12,7 @@
     <parent>
 		<groupId>org.openmrs.distro</groupId>
 		<artifactId>referenceapplication</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.7.0-SNAPSHOT</version>
 	</parent>
 
     <properties>


### PR DESCRIPTION
@dkayiwa Please look into this and see if it is valid for you to Revert OpenMRS Distro from 2.8.0-SNAPSHOT to 2.7.0-SNAPSHOT