### PR TITLE
Switching to latest versions for Ref App 2.9 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,10 @@
 
 		<openMRSVersion>2.1.3</openMRSVersion>
 		<referencemetadataVersion>2.9.0</referencemetadataVersion>
-		<logicVersion>0.5.2</logicVersion>
-		<appframeworkVersion>2.14.0-SNAPSHOT</appframeworkVersion>
+		<appframeworkVersion>2.13.0</appframeworkVersion>
 		<uiframeworkVersion>3.14.0</uiframeworkVersion>
 		<registrationcoreVersion>1.8.0</registrationcoreVersion>
-		<registrationappVersion>1.13.0-SNAPSHOT</registrationappVersion>
+		<registrationappVersion>1.12.0</registrationappVersion>
 		<eventVersion>2.7.0</eventVersion>
 		<idgenVersion>4.5.0</idgenVersion>
 		<emrapiVersion>1.27.0</emrapiVersion>
@@ -51,31 +50,31 @@
 		<metadatadeployVersion>1.10.0</metadatadeployVersion>
 		<metadatasharingVersion>1.5.0</metadatasharingVersion>
 		<metadatamappingVersion>1.3.4</metadatamappingVersion>
-		<uicommonsVersion>2.7.0-SNAPSHOT</uicommonsVersion>
+		<uicommonsVersion>2.6.1</uicommonsVersion>
 		<appuiVersion>1.9.0</appuiVersion>
 		<htmlformentryVersion>3.8.0</htmlformentryVersion>
 		<htmlformentryuiVersion>1.7.0</htmlformentryuiVersion>
 		<coreappsVersion>1.20.0</coreappsVersion>
-		<webservices.restVersion>2.25.0-SNAPSHOT</webservices.restVersion>
+		<webservices.restVersion>2.24.0</webservices.restVersion>
 		<referencedemodataVersion>1.4.4</referencedemodataVersion>
 		<dataexchangeVersion>1.3.3</dataexchangeVersion>
 		<allergyuiVersion>1.8.1</allergyuiVersion>
 		<formentryappVersion>1.4.2</formentryappVersion>
 		<atlasVersion>2.2</atlasVersion>
 		<chartsearchVersion>2.1.0</chartsearchVersion>
-		<appointmentschedulingVersion>1.11.0-SNAPSHOT</appointmentschedulingVersion>
+		<appointmentschedulingVersion>1.10.0</appointmentschedulingVersion>
 		<appointmentschedulinguiVersion>1.7.0</appointmentschedulinguiVersion>
 		<namephoneticsVersion>1.6.0</namephoneticsVersion> <!-- The omod for namephonetics is not included in the distro, but we keep the version around since it's a semi-supported add-on -->
-		<adminuiVersion>1.2.5-SNAPSHOT</adminuiVersion>
+		<adminuiVersion>1.2.4</adminuiVersion>
 		<uitestframeworkVersion>2.3.0</uitestframeworkVersion>
 		<legacyuiVersion>1.4.0</legacyuiVersion>
-		<reportingcompatibilityVersion>2.0.7-SNAPSHOT</reportingcompatibilityVersion>
-		<fhirVersion>1.17.0-SNAPSHOT</fhirVersion>
-		<owaVersion>1.9.0</owaVersion>
+		<reportingcompatibilityVersion>2.0.6</reportingcompatibilityVersion>
+		<fhirVersion>1.16.0</fhirVersion>
+		<owaVersion>1.10.0</owaVersion>
 		<reportinguiVersion>1.6.0</reportinguiVersion>
 		<addresshierarchyVersion>2.11.0</addresshierarchyVersion>
 		<!-- OWAs -->
-		<sysadminVersion>1.1</sysadminVersion>
+		<sysadminVersion>1.2</sysadminVersion>
 		
 	</properties>
 


### PR DESCRIPTION
Switching to latest versions for Ref App 2.9 release.

From Reference Application 2.9, the logic module will no longer be included in the reference application package.