### PR TITLE
Removed logic module as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,12 +164,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
-				<artifactId>logic-api</artifactId>
-				<version>${logicVersion}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.openmrs.module</groupId>
 				<artifactId>registrationcore-api</artifactId>
 				<version>${registrationcoreVersion}</version>
 				<scope>provided</scope>


### PR DESCRIPTION
The logic module is not deprecated and is no longer part of the ref app distro. Hence all dependencies to it have been removed. 