### PR TITLE
RA-1571: Add Attachments module to Reference Application Distribution

### DIFF
--- a/package/src/main/resources/openmrs-distro.properties
+++ b/package/src/main/resources/openmrs-distro.properties
@@ -44,6 +44,7 @@ omod.fhir=${fhirVersion}
 omod.owa=${owaVersion}
 omod.reportingui=${reportinguiVersion}
 omod.addresshierarchy=${addresshierarchyVersion}
+omod.attachments=${attachmentsVersion}
 owa.openmrs-owa-sysadmin=${sysadminVersion}
 db.h2.supported=false
 db.sql=classpath://openmrs-distro.sql

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 		<owaVersion>1.10.0</owaVersion>
 		<reportinguiVersion>1.6.0</reportinguiVersion>
 		<addresshierarchyVersion>2.11.0</addresshierarchyVersion>
+		<attachmentsVersion>2.0.0</attachmentsVersion>
 		<!-- OWAs -->
 		<sysadminVersion>1.2</sysadminVersion>
 		


### PR DESCRIPTION
From Ref App 2.9 onwards, the [attachments module](https://addons.openmrs.org/show/org.openmrs.module.attachments) will officially be a part of the distribution.

Issue: https://issues.openmrs.org/browse/RA-1571