### PR TITLE
Switching from SNAPSHOT to latest release version of FHIR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 		<uitestframeworkVersion>2.3.0</uitestframeworkVersion>
 		<legacyuiVersion>1.5.0</legacyuiVersion>
 		<reportingcompatibilityVersion>2.0.6</reportingcompatibilityVersion>
-		<fhirVersion>1.20.0-SNAPSHOT</fhirVersion>
+		<fhirVersion>1.19.0</fhirVersion>
 		<owaVersion>1.10.0</owaVersion>
 		<reportinguiVersion>1.6.0</reportinguiVersion>
 		<addresshierarchyVersion>2.11.0</addresshierarchyVersion>


### PR DESCRIPTION
After doing a release to maven with Bamboo, FHIR switched to snapshot, so this PR reverts using released stable version.