### PR TITLE
RA-1686 : Upgrade Reff App 2.10  to run on Platform 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<openMRSVersion>2.2.0</openMRSVersion>
+		<openMRSVersion>2.3.0-SNAPSHOT</openMRSVersion>
 		<referencemetadataVersion>2.10.1</referencemetadataVersion>
 		<appframeworkVersion>2.13.0</appframeworkVersion>
 		<uiframeworkVersion>3.15.0</uiframeworkVersion>


### PR DESCRIPTION
Ticket :https://issues.openmrs.org/browse/RA-1686
 
Reff App 2.10 should run on platform 2.3