### PR TITLE
TRUNK-4830 add missing references to liquibasechangelog table

### DIFF
--- a/package/src/main/resources/openmrs-distro.sql
+++ b/package/src/main/resources/openmrs-distro.sql
@@ -2849,6 +2849,18 @@ INSERT INTO `liquibasechangelog` VALUES ('0','bwolfe','liquibase-update-to-lates
 UNLOCK TABLES;
 
 --
+-- Add missing references to two more change sets from `openmrs-core/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-1.9.x.xml` to the table `liquibasechangelog`.
+--
+-- openmrs-core/api uses Liquibase snapshots since 2.4.0 and without those references updating the OpenMRS database fails.
+--
+
+LOCK TABLES `liquibasechangelog` WRITE;
+/*!40000 ALTER TABLE `liquibasechangelog` DISABLE KEYS */;
+INSERT INTO `liquibasechangelog` VALUES ('20120529-2230','mvorobey','liquibase-schema-only.xml','2016-07-07 08:14:28',401,'EXECUTED',NULL,'Add Foreign Key Constraint','',NULL,'2.0.5'),('20120529-2231','mvorobey','liquibase-schema-only.xml','2016-07-07 08:14:28',402,'EXECUTED',NULL,'Add Foreign Key Constraint','',NULL,'2.0.5');
+/*!40000 ALTER TABLE `liquibasechangelog` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `liquibasechangeloglock`
 --
 


### PR DESCRIPTION
https://issues.openmrs.org/browse/TRUNK-4830 introduced Liquibase snapshots on May 13 2020. 

Since then the reference application fails on startup when updating the database.

The reason for this error is that two change sets are missing from the `liquibasechangelog` table.

This commit adds the missing records to the table.