### PR TITLE
RATEST-97:Fix AddDiagnosisToVisitNoteTest

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddDiagnosisToVisitNoteTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddDiagnosisToVisitNoteTest.java
@@ -11,7 +11,6 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
@@ -36,22 +35,19 @@ public class AddDiagnosisToVisitNoteTest extends LocationSensitiveApplicationTes
         createTestVisit();
     }
    
-    @Ignore
+    @Test
     @Category(BuildTests.class)
     public void AddDiagnosisToVisitNoteTest() {
 
         ActiveVisitsPage activeVisitsPage = homePage.goToActiveVisitsSearch();
         activeVisitsPage.search(patient.identifier);
-
         ClinicianFacingPatientDashboardPage patientDashboardPage = activeVisitsPage.goToPatientDashboardOfLastActiveVisit();
         VisitNotePage visitNotePage = patientDashboardPage.goToVisitNote();
         visitNotePage.enterDiagnosis("Pne");
         visitNotePage.enterSecondaryDiagnosis("Bleed");
         assertEquals("Pneumonia", visitNotePage.primaryDiagnosis());
         assertEquals("Bleeding", visitNotePage.secondaryDiagnosis());
-
         patientDashboardPage = visitNotePage.save();
-
         List<String> diagnoses = patientDashboardPage.getDiagnoses();
         assertThat(diagnoses, hasItems("Pneumonia", "Bleeding"));
     }


### PR DESCRIPTION
Ticket Id:https://issues.openmrs.org/browse/RATEST-97

Description
Fixed AddDiagnosisToVisitNoteTest,things look good locally no breaking tests ,the tests also run as expected on testing in the browser cc @k-joseph  