### PR TITLE
RATEST-97:Fix AddDiagnosisToVisitNoteTest

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddDiagnosisToVisitNoteTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddDiagnosisToVisitNoteTest.java
@@ -11,7 +11,6 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
@@ -35,8 +34,7 @@ public class AddDiagnosisToVisitNoteTest extends LocationSensitiveApplicationTes
         patient = createTestPatient();
         createTestVisit();
     }
-
-    @Ignore
+    @Test
     @Category(BuildTests.class)
     public void AddDiagnosisToVisitNoteTest() {
 


### PR DESCRIPTION
Ticket Id:https://issues.openmrs.org/browse/RATEST-97

Description
Fixed AddDiagnosisToVisitNoteTest,things look good locally no breaking tests ,the tests also run as expected on testing in the browser cc @k-joseph