### PR TITLE
RATEST-124: Retrieving the user Selected-Location element

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/ReferenceApplicationTestBase.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/ReferenceApplicationTestBase.java
@@ -39,7 +39,7 @@ public class ReferenceApplicationTestBase extends TestBase {
 	}
 
 	public String getLocationUuid(Page page){
-		return page.findElement(SELECTED_LOCATION).getAttribute("location-uuid");
+		return driver.findElement(SELECTED_LOCATION).getAttribute("location-uuid");
 	}
 
 	@Override


### PR DESCRIPTION
Ticket ID: https://issues.openmrs.org/browse/RATEST-124

Description
Failure when retrieving the user Selected-Location element in distro during test builds