### PR TITLE
RATEST-113: Failing Test on Firefox

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/ManageProviderSchedulesTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/ManageProviderSchedulesTest.java
@@ -39,7 +39,7 @@ public class ManageProviderSchedulesTest extends ReferenceApplicationTestBase {
 	@Before
 	public void setUp() throws Exception {
 		homePage = new HomePage(page);
-		assertPage(homePage);
+		assertPage(homePage.waitForPage());
 		AppointmentSchedulingPage appointmentSchedulingPage = homePage.goToAppointmentScheduling();
 		appointmentBlocksPage = appointmentSchedulingPage.goToAppointmentBlock();
 		/*


### PR DESCRIPTION
Ticket ID: https://issues.openmrs.org/browse/RATEST-113

Description:
Tests classes that consumes ManageProviderScheduleTest fails on firefox engine