### PR TITLE
RATEST-147: ci format workflow fails on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Legacy Selenium Firefox
 on:
   push:
     branches: [master]
-  pull_request:
+  pull_request_target:
     branches: [master]
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
Ticket ID: https://issues.openmrs.org/browse/RATEST-147

Description
ci format workflow fails on forks. See the logs [here](https://github.com/kdaud/openmrs-contrib-uitestframework/runs/2653112821?check_suite_focus=true#step:2:6)