### PR TITLE
RATEST-112 - AddEditAppointmentBlockTest

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddEditAppointmentBlockTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddEditAppointmentBlockTest.java
@@ -17,7 +17,6 @@ import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
 import static org.junit.Assert.assertTrue;
 
-
 public class AddEditAppointmentBlockTest extends ManageProviderSchedulesTest {
 
 	private final String startTimeFirstAppointment = "09";
@@ -73,5 +72,4 @@ public class AddEditAppointmentBlockTest extends ManageProviderSchedulesTest {
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
-
 }

--- a/ui-tests/src/test/java/org/openmrs/reference/AddEditAppointmentBlockTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddEditAppointmentBlockTest.java
@@ -12,13 +12,12 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
 import static org.junit.Assert.assertTrue;
 
-@Ignore
+
 public class AddEditAppointmentBlockTest extends ManageProviderSchedulesTest {
 
 	private final String startTimeFirstAppointment = "09";


### PR DESCRIPTION
## What I have done
Removed @ignore tag and the test can pass on both firefox and chrome in both with head and headless states.
 ## Ticket worked on
[RATEST-112](https://issues.openmrs.org/browse/RATEST-112)
