### PR TITLE
RATEST-74:Followup commit ignoring the FormTest

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/FormTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/FormTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
@@ -22,7 +21,6 @@ import org.openqa.selenium.By;
 /**
  * Created by nata on 24.06.15.
  */
-@Ignore
 public class FormTest extends TestBase {
 	
 	private static String name = "newFormTest1";


### PR DESCRIPTION
Follow up https://issues.openmrs.org/browse/RATEST-74    
Have ignored this formTest simply to track the logs with in the bamboo that recently broke, Running this test locally passes on both headless to false or true, so am tracking this in bambooo again  , Let us track bamboo failures from this ticket after merge since this runs perfect on chrome and firefox , so its becoming so wierd if it fails on bamboo after its merged 


cc @ibacher  @dkayiwa  @kdaud 