### PR TITLE
Use HomePage.go()  Instead of HeaderPage.clickOnHomeLink()

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/FormTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/FormTest.java
@@ -17,30 +17,20 @@ import org.openmrs.reference.page.ManageHtmlFormsPage;
 import org.openmrs.uitestframework.test.TestBase;
 import org.openqa.selenium.By;
 
-
 /**
  * Created by nata on 24.06.15.
  */
 public class FormTest extends TestBase {
 	
 	private static String name = "newFormTest1";
-	
 	private static String description = "description of new form";
-	
 	private static String version = "1.2";
-	
 	private HomePage homePage;
-	
 	private AdministrationPage administrationPage;
-	
 	private HeaderPage headerPage;
-	
 	private ManageFormsPage manageForm;
-	
 	private ManageHtmlFormsPage manageHtmlFormsPage;
-	
 	private HtmlFormsPage htmlFormsPage;
-	
 	private ClinicianFacingPatientDashboardPage patientDashboardPage;
 	
 	@Before
@@ -70,8 +60,7 @@ public class FormTest extends TestBase {
 	
 	@Test
 	@Category(BuildTests.class)
-	public void addFormTest() throws Exception {
-		
+	public void addFormTest() throws Exception {	
 		initiateFormPresence();
 		manageForm.add();
 		manageForm.addLabel("Eye Report");
@@ -85,7 +74,6 @@ public class FormTest extends TestBase {
 	@Test
 	@Category(BuildTests.class)
 	public void editFormTest() throws Exception {
-		
 		addFormTest();
 		homePage.goToManageForm();
 		manageForm.waitForPage();
@@ -99,7 +87,6 @@ public class FormTest extends TestBase {
 	@Test
 	@Category(BuildTests.class)
 	public void deleteFormTest() throws Exception {
-		
 		addFormTest();
 		homePage.goToManageForm();
 		manageForm.waitForPage();
@@ -109,10 +96,6 @@ public class FormTest extends TestBase {
 	
 	@After
 	public void tearDown() throws Exception {
-		if (headerPage != null) {
-			headerPage.clickOnHomeIcon();
-			headerPage.waitForPageToLoad();
-			headerPage.logOut();
-		}
+	       homePage.go();
 	}
 }

--- a/ui-tests/src/test/java/org/openmrs/reference/FormTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/FormTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
@@ -22,7 +21,6 @@ import org.openqa.selenium.By;
 /**
  * Created by nata on 24.06.15.
  */
-@Ignore
 public class FormTest extends TestBase {
 	
 	private static String name = "newFormTest1";

--- a/ui-tests/src/test/java/org/openmrs/reference/FormTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/FormTest.java
@@ -96,6 +96,6 @@ public class FormTest extends TestBase {
 	
 	@After
 	public void tearDown() throws Exception {
-	       homePage.go();
+	        homePage.go();
 	}
 }


### PR DESCRIPTION
Follow up https://issues.openmrs.org/browse/RATEST-74
 cc @kdaud @dkayiwa @ibacher 
What changed in this pull request
i would not say this would be the fix to the bamboo logs directly due to the failures https://ci.openmrs.org/browse/REFAPP-UI-428 , however this should fix the ci to green without causing any issues
i deleted the functionality in tear down part of extending the automation to headerPage which is resulting into the failures on bamboo by the visibility of an element. One easiest and clean way is to add the delete function in tear down part, this could be the right and easiest way to fix this without harming anything and leaving all the functionalities working as expected 
