### PR TITLE
RATEST-213: Explicitly import pages than using wildcard

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddPatientAppointmentTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddPatientAppointmentTest.java
@@ -16,7 +16,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
-import org.openmrs.reference.page.*;
+import org.openmrs.reference.page.AppointmentSchedulingPage;
+import org.openmrs.reference.page. ManageProviderSchedulesPage;
+import org.openmrs.reference.page.HomePage;
+import org.openmrs.reference.page.FindPatientPage;
+import org.openmrs.reference.page.ManageAppointmentsPage;
 import org.openmrs.uitestframework.test.TestData;
 
 import static org.junit.Assert.assertTrue;
@@ -24,7 +28,6 @@ import static org.junit.Assert.assertTrue;
 public class AddPatientAppointmentTest extends LocationSensitiveApplicationTestBase {
 
     private static final String SERVICE_NAME = "Oncology";
-
     private TestData.PatientInfo patient;
 
     @Before

--- a/ui-tests/src/test/java/org/openmrs/reference/AddPatientAppointmentTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddPatientAppointmentTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
 import org.openmrs.reference.page.AppointmentSchedulingPage;
-import org.openmrs.reference.page. ManageProviderSchedulesPage;
+import org.openmrs.reference.page.ManageProviderSchedulesPage;
 import org.openmrs.reference.page.HomePage;
 import org.openmrs.reference.page.FindPatientPage;
 import org.openmrs.reference.page.ManageAppointmentsPage;

--- a/ui-tests/src/test/java/org/openmrs/reference/DeleteRequestAppointmentTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/DeleteRequestAppointmentTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertTrue;
 public class DeleteRequestAppointmentTest extends LocationSensitiveApplicationTestBase {
 
     private static final String SERVICE_NAME = "Oncology";
-
     private TestData.PatientInfo patient;
 
     @Before

--- a/ui-tests/src/test/java/org/openmrs/reference/DeleteRequestAppointmentTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/DeleteRequestAppointmentTest.java
@@ -16,7 +16,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
-import org.openmrs.reference.page.*;
+import org.openmrs.reference.page.ActiveVisitsPage;
+import org.openmrs.reference.page.ClinicianFacingPatientDashboardPage;
+import org.openmrs.reference.page.RequestAppointmentPage;
+import org.openmrs.reference.page.ManageAppointmentsPage;
 import org.openmrs.uitestframework.test.TestData;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
This PR addresses --> [ticket](https://issues.openmrs.org/browse/RATEST-213) in trying to replace importation of pages using wild cards with importing of specific pages to be used in **Delete Request Appointment and Add Patient Appointment Tests**  and also remove some unnecessary spaces in the test classes