### PR TITLE
RATEST-218: Temporarily ignore addPatientAppointment and bookRequestAppointment tests from master build plan

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/AddPatientAppointmentTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/AddPatientAppointmentTest.java
@@ -12,6 +12,7 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
@@ -20,6 +21,7 @@ import org.openmrs.uitestframework.test.TestData;
 
 import static org.junit.Assert.assertTrue;
 
+@Ignore
 public class AddPatientAppointmentTest extends LocationSensitiveApplicationTestBase {
 
     private static final String SERVICE_NAME = "Oncology";

--- a/ui-tests/src/test/java/org/openmrs/reference/BookRequestAppointmentTest.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/BookRequestAppointmentTest.java
@@ -11,6 +11,7 @@ package org.openmrs.reference;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.openmrs.reference.groups.BuildTests;
@@ -25,6 +26,7 @@ import org.openmrs.uitestframework.test.TestData;
 
 import static org.junit.Assert.assertTrue;
 
+@Ignore
 public class BookRequestAppointmentTest extends LocationSensitiveApplicationTestBase {
 
     private static final String SERVICE_NAME = "Oncology";


### PR DESCRIPTION
Ticket [ID](https://issues.openmrs.org/browse/RATEST-218)

Description -> Temporarily ignore addPatientAppointment and bookRequestAppointment tests from master build plan