### PR TITLE
RATEST-243 : Adding visibility Element on ClickInActive in conditionsPage

### DIFF
--- a/ui-tests/src/test/java/org/openmrs/reference/page/ConditionsPage.java
+++ b/ui-tests/src/test/java/org/openmrs/reference/page/ConditionsPage.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.openmrs.uitestframework.page.Page;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class ConditionsPage extends Page {
 	
@@ -39,6 +40,7 @@ public class ConditionsPage extends Page {
 
     public String getFirstConditionName() {
         try {
+            waiter.until(ExpectedConditions.elementToBeClickable(FIRST_CONDITION_NAME));
             return driver.findElement(FIRST_CONDITION_NAME).getAttribute(
                     "innerText");
         } catch (Exception e) {
@@ -51,6 +53,7 @@ public class ConditionsPage extends Page {
     }
 
     public void clickInActiveTab() {
+    	waiter.until(ExpectedConditions.elementToBeClickable(TAB_INACTIVE));
         clickOn(TAB_INACTIVE);
     }
 


### PR DESCRIPTION
**TICKET ID**
 https://issues.openmrs.org/browse/RATEST-243

**DESCRIPTION**
To add a visibility element on the `clickInActive` method in `conditions Page` that was causing the build failures [here](https://github.com/openmrs/openmrs-contrib-qaframework/pull/142)