### PR TITLE
O3-913: Upgrade to Platform 2.5.0-alpha.3

### DIFF
--- a/package/distro.properties
+++ b/package/distro.properties
@@ -1,6 +1,6 @@
 name=Ref 3.x distro
 version=1.0
-war.openmrs=2.4.0
+war.openmrs=2.5.0-alpha.3
 omod.initializer=${initializer.version}
 omod.fhir2=${fhir2.version}
 omod.webservices.rest=${webservices.rest.version}


### PR DESCRIPTION
This will assist with 2.5 testing, and 2.5 has several features that we want for 3.x features (e.g. form recordable support for Orders, Allergies, and Diagnoses; Referral Orders support).

**Note:** This is mostly a placeholder PR for now; before we merge this, I’ll also update some of the config in the distro.properties file because there’s some metadata I want to add to our dev & demo environments later today.