### PR TITLE
Update metadata mapping module to 1.5.0-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/target/
 **/distro/
 **/.DS_Store
+.project
+.settings

--- a/package/distro.properties
+++ b/package/distro.properties
@@ -10,6 +10,7 @@ omod.addresshierarchy=${addresshierarchy.version}
 omod.metadatamapping=${metadatamapping.version}
 omod.metadatasharing=${metadatasharing.version}
 omod.openconceptlab=${openconceptlab.version}
+omod.cohort=${cohort.version}
 omod.owa=${owa.version}
 
 spa.frontendModules.@openmrs/esm-devtools-app=${spa.version}

--- a/package/distro.properties
+++ b/package/distro.properties
@@ -1,6 +1,6 @@
 name=Ref 3.x distro
 version=1.0
-war.openmrs=2.4.0
+war.openmrs=2.5.0-alpha.3
 omod.initializer=${initializer.version}
 omod.fhir2=${fhir2.version}
 omod.webservices.rest=${webservices.rest.version}

--- a/package/openmrs-config/pom.xml
+++ b/package/openmrs-config/pom.xml
@@ -1,10 +1,10 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.openmrs.distro</groupId>
     <artifactId>openmrs-distro-refapp</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/package/openmrs-config/pom.xml
+++ b/package/openmrs-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openmrs.distro</groupId>
     <artifactId>openmrs-distro-refapp</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -32,6 +32,7 @@
     <metadatamapping.version>1.4.0</metadatamapping.version>
     <metadatasharing.version>1.8.0</metadatasharing.version>
     <openconceptlab.version>1.2.10</openconceptlab.version>
+    <cohort.version>3.0.0-SNAPSHOT</cohort.version>
     <owa.version>1.13.0</owa.version>
   </properties>
 

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -29,7 +29,7 @@
     <idgen.version>4.7.0</idgen.version>
     <legacyui.version>1.8.4</legacyui.version>
     <addresshierarchy.version>2.14.2</addresshierarchy.version>
-    <metadatamapping.version>1.4.0</metadatamapping.version>
+    <metadatamapping.version>1.5.0-SNAPSHOT</metadatamapping.version>
     <metadatasharing.version>1.8.0</metadatasharing.version>
     <openconceptlab.version>1.2.10</openconceptlab.version>
     <cohort.version>3.0.0-SNAPSHOT</cohort.version>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -1,10 +1,10 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.openmrs.distro</groupId>
     <artifactId>openmrs-distro-refapp</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
   </parent>
 
   <artifactId>openmrs-distro-package</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openmrs.distro</groupId>
     <artifactId>openmrs-distro-refapp</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openmrs-distro-package</artifactId>

--- a/package/spa-config/pom.xml
+++ b/package/spa-config/pom.xml
@@ -1,10 +1,10 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.openmrs.distro</groupId>
     <artifactId>openmrs-distro-refapp</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/package/spa-config/pom.xml
+++ b/package/spa-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openmrs.distro</groupId>
     <artifactId>openmrs-distro-refapp</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openmrs.distro</groupId>
   <artifactId>openmrs-distro-refapp</artifactId>
   <name>Package and Run OpenMRS</name>
   <description>Convenient project to build an OpenMRS distribution and run it</description>
 
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0</version>
   <packaging>pom</packaging>
 
   <organization>
@@ -16,6 +16,7 @@
   <scm>
     <connection>scm:git:git@github.com:openmrs/openmrs-distro-referenceapplication.git</connection>
     <developerConnection>scm:git:git@github.com:openmrs/openmrs-distro-referenceapplication.git</developerConnection>
+    <tag>openmrs-distro-refapp-3.0.0</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>Package and Run OpenMRS</name>
   <description>Convenient project to build an OpenMRS distribution and run it</description>
 
-  <version>3.0.0</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <organization>
@@ -16,7 +16,7 @@
   <scm>
     <connection>scm:git:git@github.com:openmrs/openmrs-distro-referenceapplication.git</connection>
     <developerConnection>scm:git:git@github.com:openmrs/openmrs-distro-referenceapplication.git</developerConnection>
-    <tag>openmrs-distro-refapp-3.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/run/docker/docker-compose.yml
+++ b/run/docker/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build: ./proxy
     ports:
       - 80:80
+    depends_on:
+      - openmrs
 
   # Frontend
   frontend:

--- a/run/docker/pom.xml
+++ b/run/docker/pom.xml
@@ -1,10 +1,10 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.openmrs.distro</groupId>
     <artifactId>openmrs-distro-refapp</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/run/docker/pom.xml
+++ b/run/docker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openmrs.distro</groupId>
     <artifactId>openmrs-distro-refapp</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
After the O3 ref app was upgraded to 2.5.0-alpha.3 it broke the metadata mapping module and I  made a corrective PR here https://github.com/openmrs/openmrs-module-metadatamapping/pull/56. This PR updates the version to Match