### PR TITLE
Temporarily switch platform from 2.6.0 SNAPSHOT to 2.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<openMRSVersion>2.6.0-SNAPSHOT</openMRSVersion>
+		<openMRSVersion>2.4.3</openMRSVersion>
 		<referencemetadataVersion>2.12.0</referencemetadataVersion>
 		<appframeworkVersion>2.16.0</appframeworkVersion>
 		<uiframeworkVersion>3.23.0-SNAPSHOT</uiframeworkVersion>


### PR DESCRIPTION
For one reason or the other,  switching qa server to run on the latest platform snapshot is causing all the automated tests to fail both on github actions and Bamboo.  I think for now we can have the server run against 2.4.3 version.