### PR TITLE
Bumping fhir2 version to 1.6.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -25,7 +25,7 @@
          we do so here so that we can utilise Maven to track updates, etc. -->
     <openmrs.version>2.5.7-SNAPSHOT</openmrs.version>
     <initializer.version>2.4.0-SNAPSHOT</initializer.version>
-    <fhir2.version>1.5.0</fhir2.version>
+    <fhir2.version>1.6.0-SNAPSHOT</fhir2.version>
     <webservices.rest.version>2.37.0-SNAPSHOT</webservices.rest.version>
     <idgen.version>4.7.0</idgen.version>
     <legacyui.version>1.11.0</legacyui.version>


### PR DESCRIPTION
Related PR: https://github.com/openmrs/openmrs-module-fhir2/pull/430