### PR TITLE
Create relationshiptypes.csv

### DIFF
--- a/distro/configuration/relationshiptypes.csv
+++ b/distro/configuration/relationshiptypes.csv
@@ -1,0 +1,11 @@
+Uuid,Void/Retire,Name,Description,Weight,Preferred,A is to b,B is to a
+2026807f-f0f1-4d87-892d-2abaa53358ae,,Spouse/Spouse,,A relationship from a spouse to their spouse,,,Spouse,Spouse
+048bd9e2-072a-46f6-b720-7e6bf4a6f1fe,,Parent/Child,A relationship from a mother/father to the child,,,Parent,Child
+c0165e10-f147-4840-a65e-e234a674706a,,Sibling/Sibling,A relationship between brother/sister or brother/brother or sister/sister,,,Sibling,Sibling
+c86d9979-b8ac-4d8c-85cf-cc04e7f16315,,Uncle/Nephew,A relationship of an uncle and his nephew,1,true,Uncle,Nephew
+3982f469-cedc-4b2d-91ea-fe38f881e1a0,true,Aunt/Niece,A relationship of an aunt and her niece,,,Aunt,Niece
+4f6b4fc4-66e5-4364-be1d-d5872ff8817e,,Friend/Friend,A relationship of friendship where there is often no biological link,,,Friend,Friend
+53d8a8f3-0084-4a52-8666-c655f5bd2689,,Supervisor/Supervisee,A description for supervisor to supervisee relationship,,,Supervisor,Supervisee
+117ac27a-7fec-4834-8fad-d967c702c15a,,Clinician/Patient,A relationship from a care provider to the patient,,,Clinician,Patient
+8c8bbfe3-8454-41f9-a180-55f7058af9bd,,Community Health Worker/Patient,CHW to Patient relationship,,,Community Health Worker,Patient
+057de23f-3d9c-4314-9391-4452970739c6,,Other/Other,A description for a relationship type not covered here,,,Other,Other


### PR DESCRIPTION
It's been bothering me that we have very few relationship examples in our Demo registration experience - e.g. you can't record a spouse relationship, and you're out of luck if the relationship type isn't listed (there was no "other" option). I wanted to merge this right away but figured it should probably wait for the next release and I wanted to double check it with folks like @ibacher & @vasharma05 first.