### PR TITLE
RA-1994: Downgrading Address Hierarchy to release 2.15.1.

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -27,7 +27,7 @@
     <initializer.version>2.4.0</initializer.version>
     <fhir2.version>1.7.0</fhir2.version>
     <webservices.rest.version>2.38.0</webservices.rest.version>
-    <addresshierarchy.version>2.16.0-SNAPSHOT</addresshierarchy.version>
+    <addresshierarchy.version>2.15.1</addresshierarchy.version>
     <idgen.version>4.8.0</idgen.version>
     <legacyui.version>1.13.0</legacyui.version>
     <metadatamapping.version>1.6.0</metadatamapping.version>


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/RA-1994