### PR TITLE
O3-1764: Added better Appointment Service type demo options

### DIFF
--- a/distro/configuration/appointmentservicedefinitions/service_definitions-core_demo.csv
+++ b/distro/configuration/appointmentservicedefinitions/service_definitions-core_demo.csv
@@ -1,3 +1,6 @@
 Uuid,Void/Retire,Name,Description,Duration,Start Time,End Time,Max Load,Speciality,Location,Label Colour
+7ba3aa21-cc56-47ca-bb4d-a60549f666c0,,General Medicine service,,,,,,9f2a8cd0-32c6-4844-8df7-1ac9c4d79943,,#feecae
+1ef43565-9c96-4f58-bfd2-c864c7cedac1,,Outpatient Department,,,,,,9f2a8cd0-32c6-4844-8df7-1ac9c4d79943,,#defbe6
+4ec5c4fe-cfe0-48ff-9e4d-2f201078feae,,Rehabilitation service,,,,,,9f2a8cd0-32c6-4844-8df7-1ac9c4d79943,,#9ef0f0
 be6c3bea-f7d6-4686-9de3-ee799d68a63f,,Malnutrition,,,,,,14106bb7-dad6-4446-809d-737f4c128ae3,,#FFFF00
 09c85fcf-a43e-424a-b3e3-8671b09eda5d,,General,,,,,,9f2a8cd0-32c6-4844-8df7-1ac9c4d79943,,#b533ff


### PR DESCRIPTION
Goal of this PR is to add some more reasonable-sounding options for Appointment Service field options to our Metadata, per https://issues.openmrs.org/browse/O3-1764. 
* I added General Medicine, Outpatient Department, and Rehabilitation as options, and used the code for the "General" service type. 
* I referenced this directory for the Specialty IDs: https://github.com/openmrs/openmrs-distro-referenceapplication/blob/main/distro/configuration/appointmentspecialities/specialities.csv 
* I *retained* the options for "General" and "Malnutrition" just in case these are part of someone's tests or Demo Data (want to keep the scope of this change impact extremely minimal).