### PR TITLE
switching qarefapp2 to platform 2.6.0-beta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<openMRSVersion>2.6.0-alpha</openMRSVersion>
+		<openMRSVersion>2.6.0-beta</openMRSVersion>
 		<referencemetadataVersion>2.13.0</referencemetadataVersion>
 		<appframeworkVersion>2.17.0</appframeworkVersion>
 		<uiframeworkVersion>3.23.0</uiframeworkVersion>


### PR DESCRIPTION
I am switch the https://qa-refapp.openmrs.org/openmrs/login.htm to run against platform 2.6.0-beta.

/cc: @dkayiwa 