### PR TITLE
Switch qa-ref2app to run against platform 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<openMRSVersion>2.6.0-beta</openMRSVersion>
+		<openMRSVersion>2.6.0</openMRSVersion>
 		<referencemetadataVersion>2.13.0</referencemetadataVersion>
 		<appframeworkVersion>2.17.0</appframeworkVersion>
 		<uiframeworkVersion>3.23.0</uiframeworkVersion>


### PR DESCRIPTION
I am switching the https://qa-refapp.openmrs.org/openmrs/login.htm to run against the newly released **platform 2.6.0**.