### PR TITLE
fix the RefApp modules versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<openMRSVersion>2.6.0</openMRSVersion>
+		<openMRSVersion>2.5.9</openMRSVersion>
 		<referencemetadataVersion>2.13.0</referencemetadataVersion>
 		<appframeworkVersion>2.17.0</appframeworkVersion>
 		<uiframeworkVersion>3.23.0</uiframeworkVersion>
@@ -68,7 +68,7 @@
 		<fhirVersion>1.8.0</fhirVersion>
 		<owaVersion>1.14.0</owaVersion>
 		<reportinguiVersion>1.11.0</reportinguiVersion>
-		<addresshierarchyVersion>2.15.0</addresshierarchyVersion>
+		<addresshierarchyVersion>2.15.1</addresshierarchyVersion>
 		<attachmentsVersion>2.7.0</attachmentsVersion>
 		<openconceptlabVersion>2.0.0</openconceptlabVersion>
 		<spaVersion>1.0.9</spaVersion>


### PR DESCRIPTION
**Description of what I changed**

1. I downgraded the platform version from 2.6.0 to 2.5.9 version to support 2.13.0 Reference Application Release.
2. Updated the resent released module versions on the pom.xml distro basing on their release version.