### PR TITLE
(fix) Updated country default to Cambodia

### DIFF
--- a/distro/configuration/addresshierarchy/addressConfiguration.xml
+++ b/distro/configuration/addresshierarchy/addressConfiguration.xml
@@ -5,7 +5,7 @@
       <field>COUNTRY</field>
       <nameMapping>Location.country</nameMapping>
       <sizeMapping>40</sizeMapping>
-      <elementDefault>addresshierarchy.cambodia</elementDefault>
+      <elementDefault>Cambodia</elementDefault>
       <requiredInHierarchy>true</requiredInHierarchy>
     </addressComponent>
     <addressComponent>


### PR DESCRIPTION
Currently, the default value for the country field in the address template is `addresshierarchy.cambodia`. This PR fixes the above said default value to the text `Cambodia`.