### PR TITLE
O3-1727: New Test Results Entry form

### DIFF
--- a/distro/configuration/ampathforms/TestResultsEntryFormv2
+++ b/distro/configuration/ampathforms/TestResultsEntryFormv2
@@ -1,0 +1,2241 @@
+{
+  "name": "Test Results Entry Form",
+  "version": "2",
+  "published": true,
+  "retired": false,
+  "encounter": "Lab Results",
+  "pages": [
+    {
+      "label": "Hematology",
+      "sections": [
+        {
+          "label": "Complete Blood Count",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "White Blood Cells (WBC) (10^3/uL)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualInputWhiteBloodCells",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "678AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "678"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "391558003"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "53225-9"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "678"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "680"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "649"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "923338"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "676"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Red Blood Cells (RBC) (10^6/uL)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryRedBloodCells",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "679AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "23859-2"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "679"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "681"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "923240"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "682"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "679"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "14089001"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Platelets (10^3/mL)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryPlatelets",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "729AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "687330"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "729"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "729"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "6348"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "26515-7"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "61928009"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "651"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "729"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Neutrophils (%)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryNeutrophilsMicroscopic",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1336AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "3060"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "1060713"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "30630007"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1336"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1336"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "MCV (fL) - Mean Corpuscular Volume",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryMCV",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "851AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "851"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "30929612"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "787-2"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "104133003"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "851"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "MCH (pg) - Mean Corpuscular Hemoglobin",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryMCH",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1018AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "1074253"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1018"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1018"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "54706004"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "28539-5"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "MCHC (g/dL) - Mean Cell Hemoglobin Concentration",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryMCHC",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1017AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1017"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "28540-3"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "37254006"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1017"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "1068576"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Lymphocytes (%) - microscopic exam",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryLymphocytesMicroscopic",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1338AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1338"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1338"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "1064629"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "271036002"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Hematocrit (%)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryHematocrit",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1015AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1015"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1015"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "2464"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "365616005"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "935674"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "20570-8"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Haemoglobin (g/dL)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryHaemoglobin",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "21AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "930136"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "38082009"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH Malawi",
+                    "value": "7982"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "21"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "21"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "301"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "441689006"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "648"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "718-7"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "Combined % of monocytes, eosinophils and basophils (%)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryCombinedPercentageMonocytesEosinophilsBasophils",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "163426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163426"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "252305002"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Chemistry",
+      "sections": [
+        {
+          "label": "Chemistry Results",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Alkaline Phosphatase (U/L)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryAlkalinePhosphatase",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "785AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "850"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "271234008"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "6768-6"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "785"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "686977"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "785"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "57056007"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "Amylase (IU/L)",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryAmylase",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "601338"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "1798-8"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1299"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "31004384"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "3054"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "64435009"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1299"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "BUN (mmol/L) - Blood Urea Nitrogen",
+              "type": "obs",
+              "required": false,
+              "id": "ManualEntryBUN",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "857AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "2555"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "857"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "14937-7"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "72341003"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "857"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "923501"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Fasting Blood Glucose (mg/dL)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryFastingBloodGlucosemgdl",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "160912AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "1558-6"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "932395"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "160912"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "271062006"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "Post-Prandial Blood Glucose (mg/dL)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryPostPrandialBloodGlucosemgdl",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "160914AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "16915-1"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "160914"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "302788006"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "Serum Albumin (g/dL)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumAlbumin",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "848AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "848"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "5103"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "1751-7"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "848"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "104485008"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Calcium (mg/dL)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumCalcium",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "159497AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "3056"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "2324"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "17861-6"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "601371"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "159497"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "271240001"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Potassium (mmol/L)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumPotassium",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1133AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "271236005"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1133"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Sodium (mmol/L)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumSodium",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1132AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "2951-2"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1132"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "1132"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "5110"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1132"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "104934005"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Creatinine (umol/L)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumCreatinine",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "790AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "113075003"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "14682-9"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "790"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "790"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Total Protein (g/dL)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryTotalProtein",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "717AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "717"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "717"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "270992008"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "34405511"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Glucose (mg/dl)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumGlucosemgdl",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "887AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "932390"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "602403"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "9"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "2345-7"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "887"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "887"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "22569008"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Glucose (mmol)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumGlucosemmol",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1458AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "22569008"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1458"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Total Bilirubin (umol/L)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryTotalBilirubin",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "655AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "655"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "166610007"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "35327185"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "14631-6"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "655"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Glutamic-Oxaloacetic Transaminase (IU/L) aka SGPT, AST",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumGlutamicOxaloaceticTransaminase",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "653AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "653"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "48136-6"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "923373"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "653"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "250641004"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Alkaline Phosphatase, ALP (U/L) ",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryAlkalinePhosphastase",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "785AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "850"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "271234008"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "6768-6"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "785"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "686977"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "785"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "57056007"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Uric Acid (mg/dL)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumUricAcid",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "159825AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "275740009"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "159825"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "AMPATH",
+                    "value": "6134"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "687075"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "LOINC",
+                    "value": "3084-1"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Total Cholesterol (mmol/L)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryTotalCholesterol",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1006AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "14647-2"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "923300"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1006"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1006"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "121868005"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Triglycerides (mmol/L)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryTriglycerides",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1009AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "30953289"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1009"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "14927-8"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1009"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "14740000"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Amylase (IU/L)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryAmylase",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "601338"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "1798-8"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1299"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "31004384"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "3054"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "64435009"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1299"
+                  }
+                ],
+                "answers": []
+              }
+            },
+            {
+              "label": "Serum Carbon Dioxide CO2 (mmol/L)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySerumCarbonDioxide",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "1135AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "923383"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "30933589"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "1963-8"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "1626"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "271239003"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1135"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "1135"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "602824"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Other",
+      "sections": [
+        {
+          "label": "Urine",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Urine Culture and Sensitivity (C&S)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryCultureandSensitivityUrine",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "161156AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "161156"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "LOINC",
+                    "value": "630-4"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "273973005"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "930692"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "117010004"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "Urine Pregnancy Test",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryUrinePregnancyTest",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "45AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "167252002"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "45"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "5787"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "45"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "2106-3"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Indeterminate"
+                  },
+                  {
+                    "concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "1304AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Poor sample quality"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Urine protein (dip stick)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryUrineProteinDipStick",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "1875AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "1875"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "271346009"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH Malawi",
+                    "value": "6447"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "LOINC",
+                    "value": "50949-7"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "1874AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Trace"
+                  },
+                  {
+                    "concept": "1362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "One plus"
+                  },
+                  {
+                    "concept": "1363AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Two plus"
+                  },
+                  {
+                    "concept": "1364AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Three plus"
+                  },
+                  {
+                    "concept": "1365AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Four plus"
+                  },
+                  {
+                    "concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Positive"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Urine Bacteriuria Test",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryUrineBacteriuriaTest",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "160735AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "160735"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "167316004"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1118AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Not done"
+                  },
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Indeterminate"
+                  },
+                  {
+                    "concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Positive"
+                  },
+                  {
+                    "concept": "1067AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Unknown"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Erythrocytes presence in urine sediment by light microscopy test",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryErythrocytesPresenceInUrineSedimentByLightMicroscopyTest",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "163683AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163683"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "32776-7"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "1499AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Moderate"
+                  },
+                  {
+                    "concept": "1408AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "High"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Leukocytes presence in urine sediment by light microscopy",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryLeukocytesPresenceInUrineSedimentByLightMicroscopy",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "163684AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "PIH",
+                    "value": "14236"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163684"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "20455-2"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "252385000"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "1160AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Few"
+                  },
+                  {
+                    "concept": "1499AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Moderate"
+                  },
+                  {
+                    "concept": "1408AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "High"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Epithelial casts presence in urine sediment by light microscopy test",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryEpithelialCastsPresenceInUrineSedimentByLightMicroscopyTest",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "163692AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "25157-9"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "102838008"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163692"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "159416AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Rarely"
+                  },
+                  {
+                    "concept": "1362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "One plus"
+                  },
+                  {
+                    "concept": "1363AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Two plus"
+                  },
+                  {
+                    "concept": "1364AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Three plus"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Yeast presence in urine sediment by light microscopy",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryYeastPresenceInUrineSedimentByLightMicroscopy",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "163686AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163686"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "32356-8"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "159416AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Rarely"
+                  },
+                  {
+                    "concept": "1362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "One plus"
+                  },
+                  {
+                    "concept": "1363AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Two plus"
+                  },
+                  {
+                    "concept": "1364AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Three plus"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Yeast hyphae presence in urine sediment by light microscopy test",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryYeastHyphaePresenceInUrineSedimentByLightMicroscopyTest",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "163687AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163687"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "41865-7"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "159416AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Rarely"
+                  },
+                  {
+                    "concept": "1362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "One plus"
+                  },
+                  {
+                    "concept": "1363AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Two plus"
+                  },
+                  {
+                    "concept": "1364AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Three plus"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Spore presence in urine test",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntrySporePresenceInUrineTest",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "163688AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163688"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "159416AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Rarely"
+                  },
+                  {
+                    "concept": "1362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "One plus"
+                  },
+                  {
+                    "concept": "1363AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Two plus"
+                  },
+                  {
+                    "concept": "1364AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Three plus"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Trichomonas vaginalis presence in urine sediment by light microscopy",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryTrichomonasVaginalisPresenceInUrineSedimentByLightMicroscopy",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "163689AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163689"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "5813-1"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "1160AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Few"
+                  },
+                  {
+                    "concept": "1499AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Moderate"
+                  },
+                  {
+                    "concept": "1408AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "High"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Crystals type in urine sediment by light microscopy test",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryCrystalsTypeInUrineSedimentByLightMicroscopyTest",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "163695AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163695"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "365688004"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "5782-8"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "None"
+                  },
+                  {
+                    "concept": "1160AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Few"
+                  },
+                  {
+                    "concept": "1499AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Moderate"
+                  },
+                  {
+                    "concept": "1408AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "High"
+                  },
+                  {
+                    "concept": "163642AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Ammonium urate crystals in urine"
+                  },
+                  {
+                    "concept": "722AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Amorphous phosphate crystals"
+                  },
+                  {
+                    "concept": "163643AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Amorphous urate crystals in urine"
+                  },
+                  {
+                    "concept": "725AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Calcium oxalate crystals"
+                  },
+                  {
+                    "concept": "72695AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Calcium phosphate"
+                  },
+                  {
+                    "concept": "72703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Calcium sulfate"
+                  },
+                  {
+                    "concept": "74167AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Cystine"
+                  },
+                  {
+                    "concept": "79241AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Magnesium phosphate"
+                  },
+                  {
+                    "concept": "163644AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Triple phosphate crystals"
+                  },
+                  {
+                    "concept": "123505AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Uric Acid Crystalluria"
+                  },
+                  {
+                    "concept": "123501AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Urinary Cast, Hyaline"
+                  }
+                ]
+              },
+              "validators": []
+            }
+          ]
+        },
+        {
+          "label": "Stool",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Stool culture (bacterial)",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryStoolCultureBacterial",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "163603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "625-4"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "163603"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "117028002"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "Stool Exam",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryStoolExam",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "304AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "1069834"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "304"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "53"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "252393000"
+                  },
+                  {
+                    "relationship": "BROADER-THAN",
+                    "type": "LOINC",
+                    "value": "10704-5"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "AMPATH",
+                    "value": "304"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "148882AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Ancylostomiasis due to Ancylostoma Duodenale"
+                  },
+                  {
+                    "concept": "120759AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Cestode Infection"
+                  },
+                  {
+                    "concept": "137504AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Infection by Ascaris Lumbricoides"
+                  },
+                  {
+                    "concept": "137329AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Infection due to Entamoeba Histolytica"
+                  },
+                  {
+                    "concept": "127133AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Schistosoma Mansonii Infection"
+                  },
+                  {
+                    "concept": "5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Other"
+                  }
+                ]
+              }
+            },
+            {
+              "label": "Stool microscopy with concentration",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryStoolMicroscopyWithConcentration",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "161447AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "161447"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "LOINC",
+                    "value": "10701-1"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "252393000"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "Kinyoun's stain for coccidians",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryKinyounsStainForCoccidians",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "161448AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "36878004"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "161448"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "LOINC",
+                    "value": "654-4"
+                  }
+                ],
+                "answers": []
+              },
+              "validators": []
+            },
+            {
+              "label": "Stool fat test, semi-quantitative",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryStoolFatTestSemiQuantitative",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "161450AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "161450"
+                  },
+                  {
+                    "relationship": "NARROWER-THAN",
+                    "type": "SNOMED CT",
+                    "value": "2693007"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "LOINC",
+                    "value": "16853-4"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "1874AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Trace"
+                  },
+                  {
+                    "concept": "1362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "One plus"
+                  },
+                  {
+                    "concept": "1363AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Two plus"
+                  },
+                  {
+                    "concept": "1364AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Three plus"
+                  },
+                  {
+                    "concept": "1365AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Four plus"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Stool test for reducing substance",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryStoolTestforReducingSubstance",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "161449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "LOINC",
+                    "value": "32211-5"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "161449"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "313708008"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Positive"
+                  }
+                ]
+              },
+              "validators": []
+            },
+            {
+              "label": "Fecal Occult Blood Test",
+              "type": "obs",
+              "required": false,
+              "id": "manualEntryFecalOccultBloodTest",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "159362AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "CIEL",
+                    "value": "159362"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "LOINC",
+                    "value": "2335-8"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "SNOMED CT",
+                    "value": "104435004"
+                  },
+                  {
+                    "relationship": "SAME-AS",
+                    "type": "IMO ProcedureIT",
+                    "value": "27830692"
+                  }
+                ],
+                "answers": [
+                  {
+                    "concept": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Negative"
+                  },
+                  {
+                    "concept": "1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Indeterminate"
+                  },
+                  {
+                    "concept": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Positive"
+                  }
+                ]
+              },
+              "validators": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "processor": "EncounterFormProcessor",
+  "encounterType": "",
+  "referencedForms": [],
+  "uuid": ""
+}


### PR DESCRIPTION
Adds a simple but long Test Results Entry form that can be used to manually report recent lab results for some common test types.
The goal is to unblock groups like Faimer who want to be able to record test results, without hooking up a Lab Reporting System. 
Known deficiencies:
* The date/time stamp from the form SUBMISSION will be applied to the Test concept, even if this is not actually reflective of the Test RESULT TIME. We should come back to this in the near future when we work on improving Past Visits/RDE flows. 
* multiCheckbox was not working in the form builder ([logged here](https://github.com/openmrs/openmrs-esm-form-builder/issues/73)) so for now I was forced to use Radio where Checkbox would be much more appropriate. 


Issue for this PR: https://issues.openmrs.org/browse/O3-1727