### PR TITLE
O3-2078: Update to Lab Tests example order form

### DIFF
--- a/distro/configuration/ampathforms/lab_order_entry_form-core_demo.json
+++ b/distro/configuration/ampathforms/lab_order_entry_form-core_demo.json
@@ -1,7 +1,7 @@
 {
   "name": "Laboratory Tests",
   "description": "Simple lab order entry form",
-  "version": "2",
+  "version": "2.2",
   "published": true,
   "retired": false,
   "encounter": "Consultation",
@@ -266,6 +266,22 @@
                       {
                         "concept": "1019AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                         "label": "Complete blood count"
+                      },
+                      {
+                        "concept": "161481AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "label": "Prothrombin time"
+                      },
+                      {
+                        "concept": "161482AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "label": "International Normalized Ratio (INR)"
+                      },
+                      {
+                        "concept": "161157AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "label": "ECG: 12-Lead Electrocardiogram"
+                      },
+                      {
+                        "concept": "12AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "label": "Chest X-Ray (CXR)"
                       }
                     ]
                   }
@@ -309,7 +325,10 @@
                 ],
                 "answers": []
               },
-              "validators": []
+              "validators": [],
+              "hide": {
+                "hideWhenExpression": "sex !== 'F'"
+              }
             }
           ]
         }


### PR DESCRIPTION
This PR updates the Laboratory Tests form to include PTT, INR, ECG and CXR per faimer's request. I admit I don't love that something titled "Laboratory Tests" now also has non-Lab-tests in it, but this is all a temporary workaround anyway until we have the Lab Orders & Other Orders working in the Order Basket.  If people are really opposed to this I can always make an additional workaround form like "Other Orders" for things like ECG, CXR, Chest CT, Ultrasounds, etc, but I don't love that this just adds more bandaids.  

I also discovered 3 bugs with the Form Builder save workflow which is why I had to release this as form version 2.2 instead of 2.0 or 2.1.  

Once the form JSON was updated you can see the options showing as expected. 
![image](https://user-images.githubusercontent.com/67400059/235005595-8d601bb1-51f0-4e0f-889a-60b0bb02e71a.png)
