### PR TITLE
(chore) Add System Admin app to build config

### DIFF
--- a/frontend/spa-build-config.json
+++ b/frontend/spa-build-config.json
@@ -28,6 +28,7 @@
     "@openmrs/esm-patient-registration-app": "next",
     "@openmrs/esm-patient-search-app": "next",
     "@openmrs/esm-openconceptlab-app": "next",
+    "@openmrs/esm-system-admin-app": "next",
     "@openmrs/esm-dispensing-app": "next",
     "@openmrs/esm-fast-data-entry-app": "next",
     "@openmrs/esm-cohort-builder-app": "next",


### PR DESCRIPTION
Adds the [System Admin app](https://github.com/openmrs/openmrs-esm-admin-tools/tree/main/packages/esm-system-admin-app) to the frontend build configuration file.