### PR TITLE
Add the docker compose file used for creating pre-filled images

### DIFF
--- a/docker-compose-no-volumes.yml
+++ b/docker-compose-no-volumes.yml
@@ -1,0 +1,31 @@
+# This docker compose file is used to create a backend environment without volumes.
+version: "3.7"
+
+services:
+  backend:
+    image: openmrs/openmrs-reference-application-3-backend:${TAG:-nightly}
+    depends_on:
+      - db
+    environment:
+      OMRS_CONFIG_MODULE_WEB_ADMIN: "true"
+      OMRS_CONFIG_AUTO_UPDATE_DATABASE: "true"
+      OMRS_CONFIG_CREATE_TABLES: "true"
+      OMRS_CONFIG_CONNECTION_SERVER: db
+      OMRS_CONFIG_CONNECTION_DATABASE: openmrs
+      OMRS_CONFIG_CONNECTION_USERNAME: ${OPENMRS_DB_USER:-openmrs}
+      OMRS_CONFIG_CONNECTION_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
+      timeout: 5s
+    ports:
+      - 9000:8080
+
+  # MariaDB
+  db:
+    image: mariadb:10.8.2
+    command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci --datadir=/openmrs-db"
+    environment:
+      MYSQL_DATABASE: openmrs
+      MYSQL_USER: ${OPENMRS_DB_USER:-openmrs}
+      MYSQL_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}

--- a/docker-compose-no-volumes.yml
+++ b/docker-compose-no-volumes.yml
@@ -18,7 +18,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s
     ports:
-      - 9000:8080
+      - 8080:8080
 
   # MariaDB
   db:


### PR DESCRIPTION
## Purpose

The purpose of this pull request is to create a docker-compose file that can be used to create pre-filled Docker images. The newly added docker-compose file enables the creation of a backend environment without using volumes. With this, we can write a Bamboo job that runs the backend environment, waits for data to be generated, and obtains a Docker image that includes the data.

I have named the file docker-compose-no-volumes.yml. Let me know if there are any suggestions for the file name.

Related talk thread: https://talk.openmrs.org/t/using-pre-filled-docker-images-for-running-e2e-tests/40003