### PR TITLE
(fix) O3-221: Removed the default for the Country field

### DIFF
--- a/distro/configuration/addresshierarchy/addressConfiguration.xml
+++ b/distro/configuration/addresshierarchy/addressConfiguration.xml
@@ -5,7 +5,6 @@
       <field>COUNTRY</field>
       <nameMapping>Location.country</nameMapping>
       <sizeMapping>40</sizeMapping>
-      <elementDefault>Cambodia</elementDefault>
       <requiredInHierarchy>true</requiredInHierarchy>
     </addressComponent>
     <addressComponent>


### PR DESCRIPTION
Link to the ticket: https://issues.openmrs.org/browse/O3-2281

## Description
The default value for the `Country` field is being removed since the Country `Cambodia` doesn't relate to the refapp.