### PR TITLE
Add visit queue number in visit attributes

### DIFF
--- a/distro/configuration/attributetypes/attribute_types.csv
+++ b/distro/configuration/attributetypes/attribute_types.csv
@@ -1,3 +1,4 @@
 Uuid,Void/Retire,Entity name,Name,Description,Min occurs,Max occurs,Datatype classname,Datatype config,Preferred handler classname,Handler config,_order:1000
 57ea0cbb-064f-4d09-8cf4-e8228700491c,,Visit,Punctuality,,0,1,org.openmrs.customdatatype.datatype.ConceptDatatype,d81d4698-e78c-420d-aac5-cb1f606fb32e,,,
 aac48226-d143-4274-80e0-264db4e368ee,,Visit,Insurance Policy Number,,0,1,org.openmrs.customdatatype.datatype.FloatDatatype,,,,
+c61ce16f-272a-41e7-9924-4c555d0932c5,,Visit,Visit queue number,The visit queue number assigned to a visit when a patient is added to the queue,0,1,org.openmrs.customdatatype.datatype.FreeTextDatatype,,,,


### PR DESCRIPTION
This pr adds a visit queue number assigned to a visit when a patient is added to the queue. It gives patients privacy in a queue because its generated incrementally based on the service prefix.