### PR TITLE
(chore) Rename outpatient app to service-queues-app

### DIFF
--- a/frontend/spa-build-config.json
+++ b/frontend/spa-build-config.json
@@ -25,7 +25,7 @@
     "@openmrs/esm-patient-vitals-app": "next",
     "@openmrs/esm-active-visits-app": "next",
     "@openmrs/esm-appointments-app": "next",
-    "@openmrs/esm-outpatient-app": "next",
+    "@openmrs/esm-service-queues-app": "next",
     "@openmrs/esm-patient-list-app": "next",
     "@openmrs/esm-patient-registration-app": "next",
     "@openmrs/esm-patient-search-app": "next",


### PR DESCRIPTION
Renames the `outpatient` frontend module to `service-queues`, which reflects what the app does better.

Relates to https://github.com/openmrs/openmrs-esm-patient-management/pull/647.