### PR TITLE
(chore) Update the E2E job to handle pre release versions

### DIFF
--- a/.github/workflows/e2e-on-release.yml
+++ b/.github/workflows/e2e-on-release.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.event.pull_request.title, '(release)') }}
     outputs:
-      patient_management_version: ${{steps.versions.outputs.patient_management}}
-      patient_chart_version: ${{steps.versions.outputs.patient_chart}}
-      esm_core_version: ${{steps.versions.outputs.esm_core}}
-      form_builder_version: ${{steps.versions.outputs.form_builder}}
-      cohort_builder_version: ${{steps.versions.outputs.cohort_builder}}
+      patient_management_ref: ${{steps.refs.outputs.patient_management}}
+      patient_chart_ref: ${{steps.refs.outputs.patient_chart}}
+      esm_core_ref: ${{steps.refs.outputs.esm_core}}
+      form_builder_ref: ${{steps.refs.outputs.form_builder}}
+      cohort_builder_ref: ${{steps.refs.outputs.cohort_builder}}
 
     steps:
       - uses: actions/checkout@v4
@@ -24,8 +24,8 @@ jobs:
         run: git checkout 'HEAD^{/\(release\)}'
 
       - name: Extract version numbers from the spa-build-config.json file
-        id: versions
-        run: sh e2e_test_support_files/extract_tag_numbers.sh
+        id: refs
+        run: bash e2e_test_support_files/extract_tag_numbers.sh
 
       - name: Build and Run Containers
         run: docker-compose -f e2e_test_support_files/docker-compose-build.yml up -d
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-esm-patient-management
-          ref: refs/tags/v${{ needs.build.outputs.patient_management_version }}
+          ref: ${{ needs.build.outputs.patient_management_ref }}
           path: e2e_repo
 
       - name: Copy test environment variables
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-esm-patient-chart
-          ref: refs/tags/v${{ needs.build.outputs.patient_chart_version }}
+          ref: ${{ needs.build.outputs.patient_chart_ref }}
           path: e2e_repo
 
       - name: Copy test environment variables
@@ -195,7 +195,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-esm-form-builder
-          ref: refs/tags/v${{ needs.build.outputs.form_builder_version }}
+          ref: ${{ needs.build.outputs.form_builder_ref }}
           path: e2e_repo
 
       - name: Copy test environment variables
@@ -256,7 +256,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-esm-core
-          ref: refs/tags/v${{ needs.build.outputs.esm_core_version }}
+          ref: ${{ needs.build.outputs.esm_core_ref }}
           path: e2e_repo
 
       - name: Copy test environment variables
@@ -317,7 +317,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-esm-cohortbuilder
-          ref: refs/tags/v${{ needs.build.outputs.cohort_builder_version }}
+          ref: ${{ needs.build.outputs.cohort_builder_ref }}
           path: e2e_repo
 
       - name: Copy test environment variables

--- a/e2e_test_support_files/README.md
+++ b/e2e_test_support_files/README.md
@@ -49,4 +49,4 @@ component. It then downloads Docker images from a previous "build" job, loads th
 The workflow checks out a specific tagged version of the component's repository, the tag is imported from the previous "
 build" job. This is necessary because the goal is to perform end-to-end tests on the codebase that corresponds to a
 particular release version, rather than the code at the head of the repository. In case of using pre-releases, it checkouts
-to the main branch as we don't have a tag for pre-releases.
+to the main branch as we don't create tags for pre-releases.

--- a/e2e_test_support_files/README.md
+++ b/e2e_test_support_files/README.md
@@ -48,4 +48,5 @@ component. It then downloads Docker images from a previous "build" job, loads th
 
 The workflow checks out a specific tagged version of the component's repository, the tag is imported from the previous "
 build" job. This is necessary because the goal is to perform end-to-end tests on the codebase that corresponds to a
-particular release version, rather than the code at the head of the repository.
+particular release version, rather than the code at the head of the repository. In case of using pre-releases, it checkouts
+to the main branch as we don't have a tag for pre-releases.

--- a/e2e_test_support_files/extract_tag_numbers.sh
+++ b/e2e_test_support_files/extract_tag_numbers.sh
@@ -5,9 +5,16 @@ get_repository_tag() {
   local file="$1"
   local repo_name="$2"
   local app="$3"
-  local value
-  value=$(awk -F'"' -v app="$app" '$0 ~ app {print $4}' "$file")
-  echo "$repo_name=$value"
+
+  local version=$(awk -F'"' -v app="$app" '$0 ~ app {print $4}' "$file")
+  local ref="refs/tags/v$version"
+
+  # Check if the version number contains "pre" and modify the ref to main branch
+  if [[ $version == *"pre"* ]]; then
+    ref="main"
+  fi
+
+  echo "$repo_name=$ref"
 }
 
 file_path="frontend/spa-build-config.json"


### PR DESCRIPTION
This pull request aims to facilitate the process of checking out to the main branch of the associated mono repository when the corresponding release is a pre-release when running e2e tests. For detailed information, refer to the updated documentation available [here](https://github.com/jayasanka-sack/openmrs-distro-referenceapplication/tree/e2e-refs/e2e_test_support_files#why-check-out-to-the-tags).