### PR TITLE
(feat) Allow image to use different frontend setup by modifying spa-build-config.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ### Dev Stage
-FROM openmrs/openmrs-core:dev as dev
+FROM --platform=$BUILDPLATFORM openmrs/openmrs-core:dev as dev
 WORKDIR /openmrs_distro
 
 ARG MVN_ARGS_SETTINGS="-s /usr/share/maven/ref/settings-docker.xml -U"
@@ -25,7 +25,7 @@ RUN mvn $MVN_ARGS_SETTINGS clean
 
 ### Run Stage
 # Replace 'nightly' with the exact version of openmrs-core built for production (if available)
-FROM openmrs/openmrs-core:nightly
+FROM --platform=$BUILDPLATFORM openmrs/openmrs-core:nightly
 
 # Do not copy the war if using the correct openmrs-core image version
 COPY --from=dev /openmrs/distribution/openmrs_core/openmrs.war /openmrs/distribution/openmrs_core/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.3
-FROM --platform=$BUILDPLATFORM node:18-alpine as dev
-
+ARG NODE_VERSION=18
 ARG APP_SHELL_VERSION=next
+
+FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-alpine as dev
 
 RUN mkdir -p /app
 WORKDIR /app
@@ -11,22 +12,37 @@ COPY spa-build-config.json .
 ARG CACHE_BUST
 RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} assemble --manifest --mode config --config spa-build-config.json --target ./spa
 RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} build --build-config spa-build-config.json --target ./spa
-RUN if [ ! -f ./spa/index.html ]; then echo 'Build failed. Please check the logs above for details. This may have happened because of an update to a library that OpenMRS depends on.'; exit 1; fi
+RUN if [ ! -f ./spa/index.html ]; then echo 'Build failed. Please check the logs above for details. This may have happened because of an update to a library that OpenMRS depends on.' >&2 ; exit 1; fi
 
-FROM nginx:1.25-alpine
+FROM --platform=$BUILDPLATFORM nginx:1.25-alpine
 
 RUN apk update && \
     apk upgrade && \
     # add more utils for sponge to support our startup script
-    apk add --no-cache moreutils
+    apk add --no-cache moreutils perl-utils
 
 # clear any default files installed by nginx
 RUN rm -rf /usr/share/nginx/html/*
+
+ENV APP_SHELL_VERSION ${APP_SHELL_VERSION:-next}
+
+# the default nginx image doesn't have Node or NPM, so we copy it from the dev image
+COPY --from=dev /usr/lib /usr/lib
+COPY --from=dev /usr/local/lib /usr/local/lib
+COPY --from=dev /usr/local/include /usr/local/include
+COPY --from=dev /usr/local/bin /usr/local/bin
 
 COPY startup.sh /usr/local/bin/startup.sh
 RUN chmod +x /usr/local/bin/startup.sh
 
 COPY nginx.conf /etc/nginx/nginx.conf
+
+# allow updating by overwriting spa-build-config.json
+RUN mkdir -p /openmrs
+COPY --from=dev /app/spa-build-config.json /openmrs/spa-build-config.json
+WORKDIR /openmrs
+RUN shasum -a 512 spa-build-config.json | tee spa-build-config.json.sha512sum
+WORKDIR /
 
 COPY --from=dev /app/spa /usr/share/nginx/html
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM nginx:1.25-alpine
+FROM --platform=$BUILDPLATFORM nginx:1.25-alpine
 
 ENV FRAME_ANCESTORS ""
 


### PR DESCRIPTION
This PR attempts to add a feature to make the frontend image re-usable outside of the RefApp context without interfering with the RefApp image. The main idea here is that the spa-build-config.json file is relatively well-understood mechanism to describe a frontend, so if the user supplies a new spa-build-config.json, we simply process it and replace the frontend with that. This is checked for by using the SHA-512 sum of the spa-build-config.json.

I'm less than happy with the story around how this checksum is persisted; specifically, the "base" checksum is part of the image (to prevent needing to rebuild if you're not modifying the spa-build-config.json), but if the spa-build-config.json is modified, although the checksum file is updated, this may not be persisted in the same way.

I'm also unsure that this method of adding to the image is suitable for most use-cases of modifying the frontend.