### PR TITLE
O3-2753: Add ability to publish frontend configuration to Maven

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,7 @@
 # syntax=docker/dockerfile:1.3
+#--------------------------------------------
+# Dev Stage - Assembles and Builds Frontend
+#--------------------------------------------
 FROM --platform=$BUILDPLATFORM node:18-alpine as dev
 
 ARG APP_SHELL_VERSION=next
@@ -14,11 +17,14 @@ RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} assemble --manifes
 RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} build --build-config spa-build-config.json --target ./spa
 RUN if [ ! -f ./spa/index.html ]; then echo 'Build failed. Please check the logs above for details. This may have happened because of an update to a library that OpenMRS depends on.'; exit 1; fi
 
+#--------------------------------------------
+# Runtime Stage - Published Image
+#--------------------------------------------
 FROM nginx:1.25-alpine
 
 RUN apk update && \
     apk upgrade && \
-    # add more utils for sponge to support our startup script
+    # add more utils for sponge and envsubst
     apk add --no-cache moreutils
 
 # clear any default files installed by nginx

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openmrs.distro</groupId>
+    <artifactId>referenceapplication</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>referenceapplication-frontend</artifactId>
+  <name>OpenMRS frontend</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+     <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>package-distro-artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>src/main/assembly/assembly.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/frontend/src/main/assembly/assembly.xml
+++ b/frontend/src/main/assembly/assembly.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+    http://maven.apache.org/plugins/maven-assembly-plugin/assembly/2.1.1
+      https://maven.apache.org/xsd/assembly-2.1.1.xsd"
+>
+  <id>zip-distro-dir</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/src/main/resources</directory>
+      <outputDirectory>..</outputDirectory>
+      <excludes>
+        <exclude>.gitkeep</exclude>
+      </excludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,6 @@
     </developer>
   </developers>
 
-  <modules>
-    <module>distro</module>
-  </modules>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -216,4 +212,19 @@
       <url>https://mavenrepo.openmrs.org/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
+
+  <profiles>
+    <profile>
+      <id>distro</id>
+      <modules>
+        <module>distro</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>frontend</id>
+      <modules>
+        <module>frontend</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Apparently I lied and there was more. This adds a POM and some structure to allow us to publish the `spa-assemble-config.json` (with version numbers) and the `spa-build-config.json` files as a Maven artifact.

In CI we will have something like this:

```sh
docker create --name=openmrs-frontend-container openmrs/openmrs-reference-application-3-frontend:nightly
docker cp openmrs-frontend-container:/usr/share/nginx/html/spa-assemble-config.json src/main/resources/spa-assemble-config.json
docker rm openmrs-frontend-container
```

Note that this means that the POM in the `frontend` directory is intended only as a "publication POM" and not a "actual build".