### PR TITLE
(feat) O3-2948 Add frontend config to RefApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,6 @@ To help us keep track of things, we ask that you suffix any files you add with e
 those that should be part of the core package. For example, a form named `test_form.json` would become
 `test_core-core_demo.json`.
 
+Frontend configuration can be found in `frontend/config-core_demo.json`.
+
 Thanks!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       SPA_PATH: /openmrs/spa
       API_URL: /openmrs
-      SPA_CONFIG_URLS:
+      SPA_CONFIG_URLS: config-core_demo.json
       SPA_DEFAULT_LOCALE:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -36,5 +36,6 @@ RUN chmod +x /usr/local/bin/startup.sh
 COPY nginx.conf /etc/nginx/nginx.conf
 
 COPY --from=dev /app/spa /usr/share/nginx/html
+COPY config-core_demo.json /usr/share/nginx/html
 
 CMD ["/usr/local/bin/startup.sh"]

--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -1,0 +1,5 @@
+{
+  "@openmrs/esm-styleguide": {
+    "Brand color #1": "#005d5d"
+  }
+}


### PR DESCRIPTION
As mentioned in [O3-2948](https://openmrs.atlassian.net/browse/O3-2948), we want to be able to configure for demo data in the frontend. This PR adds the ability to do that.

 Tested as follows: 
- hard-code a different brand color in `config-core_demo.json`
- do a `docker-compose build` then `docker-compose up`. 
- verify that a different brand color shows up when going to `http://localhost`