### PR TITLE
(chore) Fix incorrect backend module versions

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -23,8 +23,8 @@
 
     <!-- track module versions
          we do so here so that we can utilise Maven to track updates, etc. -->
-    <fhir2.version>2.6.4</fhir2.version>
-    <openmrs.version>2.7.0-SNAPSHOT</openmrs.version>
+    <fhir2.version>2.0.0</fhir2.version>
+    <openmrs.version>2.6.4</openmrs.version>
     <initializer.version>2.6.0</initializer.version>
     <webservices.rest.version>2.41.0</webservices.rest.version>
     <addresshierarchy.version>2.17.0</addresshierarchy.version>
@@ -40,7 +40,7 @@
     <queue.version>2.2.1</queue.version>
     <appointments.version>2.0.0-20231101.130425-7</appointments.version>
     <teleconsultation.version>2.0.0-20230831.113926-1</teleconsultation.version>
-    <cohort.version>3.7.0-SNAPSHOT</cohort.version>
+    <cohort.version>3.7.1</cohort.version>
     <reporting.version>1.25.0</reporting.version>
     <reportingrest.version>1.14.0</reportingrest.version>
     <!-- the next three are required for reporting -->


### PR DESCRIPTION
The backend build is failing as there's a mismatch in the FHIR2 module version: https://ci.openmrs.org/browse/O3-BK-22
Caused by: https://github.com/openmrs/openmrs-distro-referenceapplication/commit/71c16efcc22663449ab7b783d689f6f2d1f69a32


Also, I've fixed the cohort module version that has been reverted with https://github.com/openmrs/openmrs-distro-referenceapplication/commit/33934930ed520928b7e1fab283e094dea0884db0