### PR TITLE
O3-3003 (fix) add mariadb param to improve performance on queries wit…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,12 @@ services:
   db:
     image: mariadb:10.8.2
     restart: "unless-stopped"
-    command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci"
+    command:
+      - mysqld
+      - --character-set-server=utf8 
+      - --collation-server=utf8_general_ci
+      - --optimizer-search-depth=0 # makes queries with many JOINs not over-optimized, see:
+                                   # https://mariadb.com/docs/server/ref/mdb/system-variables/optimizer_search_depth/
     healthcheck:
       test: "mysql --user=${OMRS_DB_USER:-openmrs} --password=${OMRS_DB_PASSWORD:-openmrs} --execute \"SHOW DATABASES;\""
       interval: 3s


### PR DESCRIPTION
…h many joins

In the backend queue module, queue entry is a standard `@Resource` mounted on `/ws/rest/v1/queue-entry`. A GET request to get a list of queue entries triggers a SELECT query with 40 JOINs (not all the joined tables are unique; for example, the `users` table is joined multiple times on different keys). Changing the request to return fewer fields by doing `?v=custom:(uuid)` does not reduce the number of joins. In the refapp, with just 2 rows in the queue_entry table, the query runs very slow (> 1 min), and the nginx gateway returns a 504 time-out error after 60 seconds. I have verified that the query is properly indexed, and narrowed down that the slowness is caused by the DB's optimizer spending too much time optimizing the query. More details in [this ticket](https://openmrs.atlassian.net/browse/O3-3003). 

This PR introduces a relatively invasive fix by changing the [optimizer_search_depth](
https://mariadb.com/docs/server/ref/mdb/system-variables/optimizer_search_depth/) parameter in mariaDB, which has a default value of 62, to 0. This doesn't completely turn off this optimization; per documentation: "When it is set to 0, the optimizer tries to pick a reasonable search depth. Currently, it does this by setting the search depth to the number of tables used in the query, up to a maximum value of 7." (Curiously, this perf issue does not affect MySQL 5.6, even though it also has the same default value for `optimizer_search_depth`. It's likely using a different search algorithm).

This change reduces the query time to <200ms. However, it might also introduce unknown performance impact on things outside of the queue module. And if we go with it, we should also somehow warn other distros using MariaDB to properly configure this option.

A less invasive alternative would be to be to set the MariaDB parameter only within the particular connection making GET request to `/ws/rest/v1/queue-entry`. This requires us to, in Java, to verify that we are using MariaDB, then apply the statement `SET SESSION optimizer_search_depth = 0;` before we query. (I don't know how to do that.) One downside would be that other resources/REST endpoints that might encounter this same issue will need to apply this same fix. 

Not sure if this is the best way to go... suggestions welcome.