### PR TITLE
O3-3003 (fix) slow queries with many JOINs by upgrading mariadb to version 10.11.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,14 +45,9 @@ services:
 
   # MariaDB
   db:
-    image: mariadb:10.8.2
+    image: mariadb:10.11.7
     restart: "unless-stopped"
-    command:
-      - mysqld
-      - --character-set-server=utf8 
-      - --collation-server=utf8_general_ci
-      - --optimizer-search-depth=0 # makes queries with many JOINs not over-optimized, see:
-                                   # https://mariadb.com/docs/server/ref/mdb/system-variables/optimizer_search_depth/
+    command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci"
     healthcheck:
       test: "mysql --user=${OMRS_DB_USER:-openmrs} --password=${OMRS_DB_PASSWORD:-openmrs} --execute \"SHOW DATABASES;\""
       interval: 3s


### PR DESCRIPTION
MariaDB 10.8.2 runs unusably slow on queries with many JOINs. My [previous attempt](https://github.com/openmrs/openmrs-distro-referenceapplication/pull/799) to fix this issue by tuning a DB parameter did not work. There were non-deterministic behaviors that I did not test for, and dev3 is still experiencing the same slowness on this REST endpoint. https://dev3.openmrs.org/openmrs/ws/rest/v1/queue-entry. More details documented in [this ticket](https://openmrs.atlassian.net/browse/O3-3003).

MariaDB's issue tracker has documented the [many JOINs issue](https://jira.mariadb.org/browse/MDEV-28852) as well and has a fix available in later versions. I think upgrading would be the best way to fix this issue (rather than trying to further tune DB parameters). 10.11.7 is currently the newest version in [10.x releases](https://mariadb.org/mariadb/all-releases/).

Testing done:
More detailed repro steps documented [here](https://openmrs.atlassian.net/browse/O3-3003). Summary:
- run dockerized mariaDB with the desired version
- restore a DB dump with ~10000 queue entry rows
- Flush table and perform a query joining 40 tables. Rinse and repeat this step as it sometimes takes a few tries to get the DB to get stuck in a bad state that runs the query slowly.

I confirmed that the above steps repros the issue in 10.8.2 and confirmed that it doesn't happen on 10.11.7 after ~10 attempts. 

I have tested that upgrading mariaDB 10.8.2 to 10.11.7 needs no further upgrade steps (the DB storage files are compatible). However, when I get the DB to be stuck in the bad state in 10.8.2, upgrading to 10.11.7 does not automatically fix this issue. Instead, I have to manually do a db dump and restore it to fix it. (I might need someone with access to dev3 DB to help me with that later).



 