### PR TITLE
(feat) O3-2972: Validate number fields whose concepts don't allow decimal values

### DIFF
--- a/distro/configuration/ampathforms/TestResultsEntryFormv2-core_demo.json
+++ b/distro/configuration/ampathforms/TestResultsEntryFormv2-core_demo.json
@@ -1226,55 +1226,6 @@
               }
             },
             {
-              "label": "Amylase (IU/L)",
-              "type": "obs",
-              "required": false,
-              "id": "manualEntryAmylase",
-              "questionOptions": {
-                "disallowDecimals": true,
-                "rendering": "number",
-                "concept": "1299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "conceptMappings": [
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "IMO ProcedureIT",
-                    "value": "601338"
-                  },
-                  {
-                    "relationship": "BROADER-THAN",
-                    "type": "LOINC",
-                    "value": "1798-8"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "CIEL",
-                    "value": "1299"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "IMO ProcedureIT",
-                    "value": "31004384"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "PIH",
-                    "value": "3054"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "SNOMED CT",
-                    "value": "64435009"
-                  },
-                  {
-                    "relationship": "SAME-AS",
-                    "type": "AMPATH",
-                    "value": "1299"
-                  }
-                ],
-                "answers": []
-              }
-            },
-            {
               "label": "Serum Carbon Dioxide CO2 (mmol/L)",
               "type": "obs",
               "required": false,

--- a/distro/configuration/ampathforms/TestResultsEntryFormv2-core_demo.json
+++ b/distro/configuration/ampathforms/TestResultsEntryFormv2-core_demo.json
@@ -1,6 +1,6 @@
 {
   "name": "Laboratory Test Results",
-  "version": "2",
+  "version": "3",
   "published": true,
   "retired": false,
   "encounter": "Lab Results",
@@ -119,6 +119,7 @@
               "required": false,
               "id": "ManualEntryPlatelets",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "729AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -172,6 +173,7 @@
               "required": false,
               "id": "ManualEntryNeutrophilsMicroscopic",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "1336AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -210,6 +212,7 @@
               "required": false,
               "id": "ManualEntryMCV",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "851AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -324,6 +327,7 @@
               "required": false,
               "id": "ManualEntryLymphocytesMicroscopic",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "1338AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -459,6 +463,7 @@
               "required": false,
               "id": "ManualEntryCombinedPercentageMonocytesEosinophilsBasophils",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "163426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -543,6 +548,7 @@
               "required": false,
               "id": "ManualEntryAmylase",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "1299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -802,6 +808,7 @@
               "required": false,
               "id": "manualEntrySerumSodium",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "1132AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -878,6 +885,7 @@
               "required": false,
               "id": "manualEntryTotalProtein",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "717AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -911,6 +919,7 @@
               "required": false,
               "id": "manualEntrySerumGlucosemgdl",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "887AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -1020,6 +1029,7 @@
               "required": false,
               "id": "manualEntrySerumGlutamicOxaloaceticTransaminase",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "653AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -1058,6 +1068,7 @@
               "required": false,
               "id": "manualEntryAlkalinePhosphastase",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "785AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -1220,6 +1231,7 @@
               "required": false,
               "id": "manualEntryAmylase",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "1299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [
@@ -1268,6 +1280,7 @@
               "required": false,
               "id": "manualEntrySerumCarbonDioxide",
               "questionOptions": {
+                "disallowDecimals": true,
                 "rendering": "number",
                 "concept": "1135AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "conceptMappings": [


### PR DESCRIPTION
This PR adds validation to the Laboratory Test Results form that ensures fields of type [number](https://ampath-forms.vercel.app/docs/field-types-reference#number) whose backing concepts don't allow decimal values show an error when decimals are typed in. For example, the backing concept for `Platelets` does not allow decimal values:

![323766319-4f8adbca-0a73-43ea-9e0a-d77d5b705912](https://github.com/openmrs/openmrs-distro-referenceapplication/assets/8509731/f9656a10-a6f8-4576-a261-550f7e4bede0)

This validation logic was recently introduced to the Angular form engine [here](https://github.com/openmrs/openmrs-ngx-formentry/pull/135).

## Video of the validation in practice

https://github.com/openmrs/openmrs-distro-referenceapplication/assets/8509731/f675af6d-d540-4349-9ac1-e48a4e120a37

This change solves this error shown when submitting the form after filling in values that lie within the related reference ranges for the backing concepts but without taking into account whether the fields support decimal values or not:

<img width="1433" alt="323768777-bca7dcfe-a046-482b-97ba-9f37b094def9" src="https://github.com/openmrs/openmrs-distro-referenceapplication/assets/8509731/48697392-6447-4412-a970-cd0ababcc150">

## Related issue

https://openmrs.atlassian.net/browse/O3-2972

## Other 

I don't know what the versioning scheme in use here is. I've elected to increment the version by 1. More details about the issue are pointed out in [this PR](https://github.com/openmrs/openmrs-ngx-formentry/pull/135). 
