### PR TITLE
(fix) O3-3131 use utf8mb4 text encoding for MariaDB to handle all u…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   db:
     image: mariadb:10.11.7
     restart: "unless-stopped"
-    command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci"
+    command: "mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci"
     healthcheck:
       test: "mysql --user=${OMRS_DB_USER:-openmrs} --password=${OMRS_DB_PASSWORD:-openmrs} --execute \"SHOW DATABASES;\""
       interval: 3s


### PR DESCRIPTION
…tf8 characters

The Refapp currently uses MariaDB as its database, with utf8 as its default text encoding. However, MariaDB’s implementation of utf8 cannot handle all utf8 characters (for example: emojis). This PR changes it to use utf8mb4, which should handle all utf8 characters.

Testing done:
- Tried creating an appointment with appointment notes with emojis included. This currently fails in dev3, but passes in my local refapp instance with this change. 