### PR TITLE
Bump appointments module to 2.0.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -36,7 +36,7 @@
     <attachments.version>3.2.0</attachments.version>
     <referencedemodata.version>2.4.0</referencedemodata.version>
     <queue.version>2.4.0-SNAPSHOT</queue.version>
-    <appointments.version>2.0.0-20240305.062514-14</appointments.version>
+    <appointments.version>2.0.0-SNAPSHOT</appointments.version>
     <teleconsultation.version>2.0.0-20230831.113926-1</teleconsultation.version>
     <cohort.version>3.7.1</cohort.version>
     <reporting.version>1.26.0</reporting.version>


### PR DESCRIPTION
Bumps the appointments module to the latest snapshot to:

- Get in this [fix](https://bahmni.atlassian.net/browse/BAH-3869) which unlocks @ojwanganto's team
- Fixes failing E2E tests in this related [PR](https://github.com/openmrs/openmrs-esm-patient-management/pull/1164) in Patient Management. 