### PR TITLE
Disallow overlapping visits

### DIFF
--- a/distro/configuration/globalproperties/globalproperties-core_data.xml
+++ b/distro/configuration/globalproperties/globalproperties-core_data.xml
@@ -11,6 +11,10 @@
         <globalProperty>
             <property>visits.assignmentHandler</property>
             <value>org.openmrs.api.handler.ExistingVisitAssignmentHandler</value>
+        </globalProperty>    
+        <globalProperty>
+            <property>visits.allowOverlappingVisits</property>
+            <value>false</value>
         </globalProperty>
     </globalProperties>
 </config>


### PR DESCRIPTION
This PR addresses the issue of overlapping visits by setting the visits.allowOverlappingVisits global property to false. By default, this property is set to true in the core, which allows overlapping visits. Changing it to false will prevent overlapping visits, enhancing the accuracy and integrity of visit data.

Ticket: [O3-3499](https://openmrs.atlassian.net/browse/O3-3499)
Discussion: [Slack Discussion](https://openmrs.slack.com/archives/CHP5QAE5R/p1719486297630129)

[O3-3499]: https://openmrs.atlassian.net/browse/O3-3499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ