### PR TITLE
added ssl example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       - backend
     ports:
       - "80:80"
+  # add these lines for https
+  #      - "443:443"
+  #    volumes:
+  #      - ./nginx:/etc/nginx/conf.d
 
   frontend:
     image: openmrs/openmrs-reference-application-3-frontend:${TAG:-qa}
@@ -19,7 +23,7 @@ services:
       SPA_CONFIG_URLS: /openmrs/spa/config-core_demo.json
       SPA_DEFAULT_LOCALE:
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/"]
+      test: [ "CMD", "curl", "-f", "http://localhost/" ]
       timeout: 5s
     depends_on:
       - backend
@@ -38,7 +42,7 @@ services:
       OMRS_CONFIG_CONNECTION_USERNAME: ${OPENMRS_DB_USER:-openmrs}
       OMRS_CONFIG_CONNECTION_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/openmrs" ]
       timeout: 5s
     volumes:
       - openmrs-data:/openmrs/data

--- a/gateway/ssl.conf
+++ b/gateway/ssl.conf
@@ -1,0 +1,93 @@
+# to run the openmrs application using ssl certificates
+# modify the 'your.server.name' to your domainname in this file
+# create a 'nginx' directory where your docker.compose.yaml file is located
+# copy into this directory:
+#   1. this file
+#   2. certificate.crt
+#   3. private.key
+#
+# un-comment the lines in docker.compose under the gateway service
+# restart with: docker compose up
+
+server {
+        listen 80;
+        server_name your.server.name;
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+server {
+  listen       443 ssl;
+  server_name your.server.name;
+
+	ssl_certificate /etc/nginx/conf.d/certificate.crt;
+        ssl_certificate_key /etc/nginx/conf.d/private.key;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+
+
+  add_header X-XSS-Protection "1; mode=block";
+  add_header Content-Security-Policy $csp_header;
+  add_header X-Content-Type-Options nosniff;
+
+  proxy_set_header      HOST $host;
+  proxy_set_header      X-Forwarded-Proto $forwarded_proto;
+  proxy_set_header      X-Real-IP $forwarded_ip;
+  proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+  # if serving this via HTTPS, the following is recommended
+  # proxy_cookie_flags      $var_proxy_cookie_flags;
+  proxy_http_version    1.1;
+
+  gzip on;
+  gzip_vary on;
+  # 1 KiB
+  gzip_min_length 1024;
+  gzip_proxied any;
+  gzip_http_version 1.0;
+  gzip_types  font/eot
+              font/otf
+              font/ttf
+              image/svg+xml
+              text/css
+              text/html
+              text/javascript
+              text/plain
+              text/xml
+              application/atom+xml
+              application/geo+json
+              application/importmap+json
+              application/javascript
+              application/x-javascript
+              application/json
+              application/ld+json
+              application/fhir+json
+              application/fhir+xml
+              application/manifest+json
+              application/rdf+xml
+              application/rss+xml
+              application/xhtml+xml
+              application/xml;
+
+  # all redirects are relative to the gateway
+  absolute_redirect off;
+
+  location = /openmrs/spa {
+    return 301 /openmrs/spa/;
+  }
+
+  location /openmrs/spa/ {
+    proxy_pass http://frontend/;
+    proxy_redirect http://$host/ /openmrs/spa/;
+  }
+
+  location /openmrs {
+    proxy_pass http://backend;
+  }
+
+  location = / {
+    return 301 /openmrs/spa/;
+  }
+}


### PR DESCRIPTION
First of thank you for this docker implementation example. I am just starting using openmrs, bare with me.

This reference is working fine using just http, however for a server on the internet ssl is required.
I looked al  over the internet for an example how to add ssl certificates, but could not find any for openmrs.
I think it will be beneficial also for other users, so I added an example myself contained in the pull request.

However it has two problems you can help me with?
1. /openmrs path: invalid or missing CRSF token.
2. /openmrs/spa path: 
    a: ResizeObserver loop completed with undelivered notifications.
    b: Uncaught Error: WorkspaceOverlay or WorkspaceWindow has provided an invalid context key: "home". The context key must be part of the URL path, with no initial or trailing slash.
    
if you can me give me some suggestions how to solve this , much appreciated.
Regards,
Hans Bakker

PS: To Try yourself at our server: https://app.openrationale.net/openmrs or  https://app.openrationale.net/openmrs/spa