### PR TITLE
(chore) O3-3560: Use latest upload/download-artifact version in GH Actions

### DIFF
--- a/.github/workflows/e2e-on-release.yml
+++ b/.github/workflows/e2e-on-release.yml
@@ -37,7 +37,7 @@ jobs:
         run: sh e2e_test_support_files/commit_and_export_images.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e_release_env_images
           path: e2e_release_env_images.tar.gz
@@ -54,7 +54,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -97,7 +97,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-patient-management
@@ -115,7 +115,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -158,7 +158,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-patient-chart
@@ -176,7 +176,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -219,7 +219,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-form-builder
@@ -237,7 +237,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -280,7 +280,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-esm-core
@@ -298,7 +298,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -341,7 +341,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-cohort-builder

--- a/.github/workflows/e2e-tests-on-commit.yml
+++ b/.github/workflows/e2e-tests-on-commit.yml
@@ -23,7 +23,7 @@ jobs:
         run: sh e2e_test_support_files/commit_and_export_images.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e_release_env_images
           path: e2e_release_env_images.tar.gz
@@ -40,7 +40,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -83,7 +83,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-patient-management
@@ -101,7 +101,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -144,7 +144,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-patient-chart
@@ -162,7 +162,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -205,7 +205,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-form-builder
@@ -223,7 +223,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -266,7 +266,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-esm-core
@@ -284,7 +284,7 @@ jobs:
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Download Docker Images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e_release_env_images
           path: ${{ steps.tempdir.outputs.tmpdir }}
@@ -327,7 +327,7 @@ jobs:
         working-directory: e2e_repo
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: report-cohort-builder


### PR DESCRIPTION
https://openmrs.atlassian.net/browse/O3-3560

Most of our repositories currently use actions/upload-artifact@v3 for artifact uploading and actions/download-artifact@v3 for artifact downloading within our CI pipelines. However, an updated version, actions/upload-artifact@v4 and actions/download-artifact@v4, is now available and should be considered for adoption across our projects.