### PR TITLE
(fix): Updated nginx.conf to allow client upload upto 10MB size objects

### DIFF
--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -13,6 +13,7 @@ events {
 http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
+  client_max_body_size 10M;
 
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
I added this to fix the issue: `413 Request Entity Too Large` when trying to install some modules.