### PR TITLE
Remove webp from extensions allowlist and add pdf

### DIFF
--- a/distro/configuration/globalproperties/globalproperties-core_demo.xml
+++ b/distro/configuration/globalproperties/globalproperties-core_demo.xml
@@ -39,6 +39,6 @@
 
     <globalProperty>
         <property>attachments.allowedFileExtensions</property>
-        <value>jpeg,jpg,png,webp</value>
+        <value>jpeg,jpg,png,pdf</value>
     </globalProperty>
 </config>


### PR DESCRIPTION
Removes the `webp` file extension from the file upload allowlist. `webp` uploads don't work in O3 - see [this thread for context](https://openmrs.slack.com/archives/C02UNMKFH8V/p1730186448154179).

 Also, adds `pdf` to the allowlist.