### PR TITLE
03-4132 : Update O3 EMR Languages: Add Portuguese, and Chinese

### DIFF
--- a/distro/configuration/globalproperties/i18n-core_demo.xml
+++ b/distro/configuration/globalproperties/i18n-core_demo.xml
@@ -2,7 +2,7 @@
     <globalProperties>
         <globalProperty>
             <property>locale.allowed.list</property>
-            <value>en, en_GB, es, fr, he, km, ar, vi</value>
+            <value>en, en_GB, es, fr, he, km, ar, vi, pt, zh</value>
         </globalProperty>
     </globalProperties>
 </config>


### PR DESCRIPTION
Requirements
 This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as feat, fix, or chore, among others). See existing PR titles for inspiration.
For changes to apps
 My work conforms to the [O3 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
If applicable
 My work includes tests or is validated by existing tests.
 I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.
Summary
Added the Vietnamese and removed British English

Screenshots