### PR TITLE
(chore) set restrictByVisitLocationTag parameter to true

### DIFF
--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -1,5 +1,6 @@
 {
   "@openmrs/esm-patient-chart-app": {
+    "restrictByVisitLocationTag": true,
     "showUpcomingAppointments": true
   },
   "@openmrs/esm-service-queues-app": {


### PR DESCRIPTION
This will update the Reference Application to use the newly-implemented functionality to restrict visits to those tagged as visit locations (and to default the visit location to the "nearest" visit location associated with the session location), following the O2 Ref App model.