### PR TITLE
Update the patient chart config to order order basket action first

### DIFF
--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -8,6 +8,13 @@
       }
     }
   },
+  "@openmrs/esm-ward-app": {
+    "extensionSlots": {
+      "action-menu-ward-patient-items-slot": {
+        "add": ["order-basket-action-menu"]
+      }
+    }
+  },
   "@openmrs/esm-service-queues-app": {
     "priorityConfigs": [
       {

--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -1,7 +1,12 @@
 {
   "@openmrs/esm-patient-chart-app": {
     "restrictByVisitLocationTag": true,
-    "showUpcomingAppointments": true
+    "showUpcomingAppointments": true,
+    "extensionSlots": {
+      "action-menu-patient-chart-items-slot": {
+        "order": ["order-basket-action-menu"]
+      }
+    }
   },
   "@openmrs/esm-service-queues-app": {
     "priorityConfigs": [


### PR DESCRIPTION
This PR is created in created to keep the order basket action menu button on top of the `patient-chart-action-items-slot` in response to https://github.com/openmrs/openmrs-esm-patient-chart/pull/2130, where the `order` property of the `order-basket-action-menu` was removed to allow multiple slots for the extension mentioned above.



https://github.com/user-attachments/assets/a0ba4d7c-7331-4b1c-b220-8badd067d48f

Adding the order basket action menu button to the ward patient workspace

https://github.com/user-attachments/assets/41886c14-853b-415e-ac94-d5d7922eed50



