### PR TITLE
Revert "Simplify caching setup"

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -26,7 +26,7 @@ http {
     }
 
     # never cache the importmap, routes, or service-worker
-    location /service-worker.js {
+    location ~* (((importmap|routes\.registry)\.json)|service-worker\.js)$ {
       expires -1d;
       try_files $uri =404;
     }
@@ -34,7 +34,7 @@ http {
     # handle anything with a "." that's not an HTML
     # assume it's a static file
     location ~* \.(?!html?)[^.]+$ {
-      add_header 'Cache-Control' 'no-cache, must-revalidate'
+      expires 6M;
       try_files $uri =404;
     }
 


### PR DESCRIPTION
This reverts commit 723a9a5a1603a988142c96bf84732caf7b171804. This change in Nginx configuration has caused the Frontend images to crash (e.g. Dev3)