### PR TITLE
(refactor) Remove cohort types config

### DIFF
--- a/distro/configuration/cohorttypes/cohorttypes-core_data.csv
+++ b/distro/configuration/cohorttypes/cohorttypes-core_data.csv
@@ -1,3 +1,0 @@
-Uuid,Void/Retire,Name,Description,_order:1000
-eee9970e-7ca0-4e8c-a280-c33e9d5f6a04,,System List,A system-generated patient list,
-e71857cb-33af-4f2c-86ab-7223bcfa37ad,,My List,A user-generated patient list,


### PR DESCRIPTION
This PR removes the `cohorttypes` folder from the backend configuration since it is already included in the reference application content package - https://github.com/openmrs/openmrs-content-referenceapplication/tree/main/configuration/backend_configuration/cohorttypes