### PR TITLE
Revert initializer and core version bump

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -25,8 +25,8 @@
          we do so here so that we can utilise Maven to track updates, etc. -->
     <fhir2.version>2.3.0-SNAPSHOT</fhir2.version>
     <authentication.version>1.0.0</authentication.version>
-    <openmrs.version>2.7.2-SNAPSHOT</openmrs.version>
-    <initializer.version>2.9.0-SNAPSHOT</initializer.version>
+    <openmrs.version>2.6.15</openmrs.version>
+    <initializer.version>2.8.0</initializer.version>
     <webservices.rest.version>2.48.0-SNAPSHOT</webservices.rest.version>
     <addresshierarchy.version>2.19.0</addresshierarchy.version>
     <idgen.version>4.14.0</idgen.version>


### PR DESCRIPTION
This PR is an attempt to fix the failing e2e tests by reverting the upgrades to the initializer and core version.