### PR TITLE
Add reporting app to distro and update reporting and reportingrest modules

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -39,8 +39,8 @@
     <appointments.version>2.0.0-20240305.062514-14</appointments.version>
     <teleconsultation.version>2.0.0-20230831.113926-1</teleconsultation.version>
     <cohort.version>3.7.2</cohort.version>
-    <reporting.version>1.26.0</reporting.version>
-    <reportingrest.version>1.14.0</reportingrest.version>
+    <reporting.version>1.27.0</reporting.version>
+    <reportingrest.version>1.15.0</reportingrest.version>
     <!-- the next three are required for reporting -->
     <calculation.version>1.3.0</calculation.version>
     <htmlwidgets.version>1.11.0</htmlwidgets.version>

--- a/frontend/spa-assemble-config.json
+++ b/frontend/spa-assemble-config.json
@@ -40,7 +40,8 @@
     "@openmrs/esm-user-onboarding-app": "next",
     "@openmrs/esm-ward-app": "next",
     "@openmrs/esm-stock-management-app": "next",
-    "@openmrs/esm-billing-app": "next"
+    "@openmrs/esm-billing-app": "next",
+    "@openmrs/esm-reports-app": "next"
   },
   "excludedFrontendModules": []
 }


### PR DESCRIPTION
This diff does two things:

- Adds the new [reporting](https://github.com/openmrs/openmrs-esm-admin-tools/pull/45) ESM to the spa-assemble-config.json file so it gets included in the distro.
- Updates the `reporting` and `reportingrest` backend modules to newer versions to fix an outdated backend module dependencies warning shown when running the reporting app.