### PR TITLE
(chore) O3-4460: Prevent over-dispensing medications

### DIFF
--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -1,4 +1,9 @@
 {
+  "@openmrs/esm-dispensing-app": {
+    "dispenseBehavior": {
+      "restrictTotalQuantityDispensed": true
+    }
+  },
   "@openmrs/esm-patient-chart-app": {
     "restrictByVisitLocationTag": true,
     "showUpcomingAppointments": true,


### PR DESCRIPTION
Sets the `restrictTotalQuantityDispensed` property to `true` for the dispensing app. This ensures that the user cannot dispense more medications than the quantity prescribed. The dispense order will be marked as Complete once the quantity dispensed matches the quantity prescribed.

See [this issue thread](https://openmrs.atlassian.net/browse/O3-4460) for more context.