### PR TITLE
(chore): Bump backend dependencies

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -23,9 +23,9 @@
 
     <!-- track module versions
          we do so here so that we can utilise Maven to track updates, etc. -->
-    <fhir2.version>2.3.0-SNAPSHOT</fhir2.version>
+    <fhir2.version>2.3.0</fhir2.version>
     <authentication.version>1.1.0</authentication.version>
-    <openmrs.version>2.7.2-SNAPSHOT</openmrs.version>
+    <openmrs.version>2.7.2</openmrs.version>
     <initializer.version>2.9.0</initializer.version>
     <webservices.rest.version>2.48.0</webservices.rest.version>
     <addresshierarchy.version>2.20.0</addresshierarchy.version>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -55,8 +55,8 @@
     <stockmanagement.version>2.0.2</stockmanagement.version>
     <billing.version>1.2.0</billing.version>
     <!-- Content Packages -->
-    <reference-content.version>1.0.0-SNAPSHOT</reference-content.version>
-    <reference-demo-content.version>1.0.0-SNAPSHOT</reference-demo-content.version>
+    <reference-content.version>1.0.0</reference-content.version>
+    <reference-demo-content.version>1.0.0</reference-demo-content.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This PR bumps the versions of the demo content package and the required metadata content package, fhir2 and core versions