### PR TITLE
(chore): Remove unreleased modules

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -50,10 +50,6 @@
     <o3forms.version>2.3.0</o3forms.version>
     <emrapi.version>2.2.0</emrapi.version>
     <event.version>2.10.0</event.version>
-    <bedmanagement.version>6.0.0</bedmanagement.version>
-    <!-- Stock Management and Billing -->
-    <stockmanagement.version>2.0.2</stockmanagement.version>
-    <billing.version>1.2.0</billing.version>
     <!-- Content Packages -->
     <reference-content.version>1.0.0</reference-content.version>
     <reference-demo-content.version>1.0.0</reference-demo-content.version>
@@ -211,24 +207,6 @@
       <groupId>org.openmrs</groupId>
       <artifactId>event-omod</artifactId>
       <version>${event.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.openmrs.module</groupId>
-      <artifactId>bedmanagement-omod</artifactId>
-      <version>${bedmanagement.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.openmrs.module</groupId>
-      <artifactId>stockmanagement-omod</artifactId>
-      <version>${stockmanagement.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.openmrs.module</groupId>
-      <artifactId>billing-omod</artifactId>
-      <version>${billing.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/frontend/spa-assemble-config.json
+++ b/frontend/spa-assemble-config.json
@@ -34,8 +34,7 @@
     "@openmrs/esm-primary-navigation-app": "latest",
     "@openmrs/esm-service-queues-app": "latest",
     "@openmrs/esm-system-admin-app": "latest",
-    "@openmrs/esm-user-onboarding-app": "latest",
-    "@openmrs/esm-reports-app": "latest"
+    "@openmrs/esm-user-onboarding-app": "latest"
   },
   "excludedFrontendModules": []
 }

--- a/frontend/spa-assemble-config.json
+++ b/frontend/spa-assemble-config.json
@@ -2,7 +2,6 @@
   "frontendModules": {
     "@openmrs/esm-active-visits-app": "latest",
     "@openmrs/esm-appointments-app": "latest",
-    "@openmrs/esm-bed-management-app": "latest",
     "@openmrs/esm-cohort-builder-app": "latest",
     "@openmrs/esm-devtools-app": "latest",
     "@openmrs/esm-dispensing-app": "latest",
@@ -36,9 +35,6 @@
     "@openmrs/esm-service-queues-app": "latest",
     "@openmrs/esm-system-admin-app": "latest",
     "@openmrs/esm-user-onboarding-app": "latest",
-    "@openmrs/esm-ward-app": "latest",
-    "@openmrs/esm-stock-management-app": "latest",
-    "@openmrs/esm-billing-app": "latest",
     "@openmrs/esm-reports-app": "latest"
   },
   "excludedFrontendModules": []


### PR DESCRIPTION
This PR removes the following frontend modules from the spa-assemble.config:
- Billing
- Stock management
- Ward 
- Bed management

Should we leave in [the reports app ](https://github.com/openmrs/openmrs-esm-admin-tools/pull/45) that was introduced to the admin tools recently?