### PR TITLE
(chore) O3-4332 : Update appointments version to 2.1.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -36,7 +36,7 @@
     <attachments.version>3.6.0</attachments.version>
     <referencedemodata.version>2.5.0</referencedemodata.version>
     <queue.version>2.4.0</queue.version>
-    <appointments.version>2.0.0-20240305.062514-14</appointments.version>
+    <appointments.version> 2.1.0-SNAPSHOT</appointments.version>
     <teleconsultation.version>2.0.0-20230831.113926-1</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>
     <reporting.version>1.27.0</reporting.version>


### PR DESCRIPTION

- It seems that the API response isn't saving or displaying dateAppointmentScheduled.
- We should update the appointment module version to 2.1.0-SNAPSHOT, as suggested in this [PR](https://github.com/openmrs/openmrs-esm-patient-management/pull/1480).
[Related issue]: [O3-4432](https://openmrs.atlassian.net/browse/O3-4432).
- After upgrading to 2.1.0-SNAPSHOT, the following changes were made to fix the issue.
## Here is the screen recording after the update
https://github.com/user-attachments/assets/ab06d2ab-7710-4d22-80eb-9ab99cff0d9c



[O3-4432]: https://openmrs.atlassian.net/browse/O3-4432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ