### PR TITLE
O3-4492: Update the Queue module to 2.5.0

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -35,7 +35,7 @@
     <openconceptlab.version>2.4.0</openconceptlab.version>
     <attachments.version>3.6.0</attachments.version>
     <referencedemodata.version>2.5.0</referencedemodata.version>
-    <queue.version>2.4.0</queue.version>
+    <queue.version>2.5.0</queue.version>
     <appointments.version>2.0.0-20240305.062514-14</appointments.version>
     <teleconsultation.version>2.0.0-20230831.113926-1</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>


### PR DESCRIPTION
Queue 2.4.0 has a Liquibase error, which was fixed in 2.5.0.

Fix Commit: https://github.com/openmrs/openmrs-module-queue/commit/a7f3aa0c419e45a8f8c357f91ff19c98d85ab13b

Ticket: https://openmrs.atlassian.net/browse/O3-4492