### PR TITLE
(chore) update the Queue module to 2.6.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -35,7 +35,7 @@
     <openconceptlab.version>2.4.0</openconceptlab.version>
     <attachments.version>3.6.0</attachments.version>
     <referencedemodata.version>2.5.0</referencedemodata.version>
-    <queue.version>2.5.0</queue.version>
+    <queue.version>2.6.0-SNAPSHOT</queue.version>
     <appointments.version>2.0.0-20240305.062514-14</appointments.version>
     <teleconsultation.version>2.0.0-20230831.113926-1</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>


### PR DESCRIPTION
queues module version 2.5.0 had a [critical NPE error](https://openmrs.atlassian.net/browse/O3-4473) when attempting to add queue entries. Bumping it to 2.6.0-SNAPSHOT instead.