### PR TITLE
(chore): Bump version of content packages

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -55,7 +55,7 @@
     <stockmanagement.version>2.0.2</stockmanagement.version>
     <billing.version>1.2.0</billing.version>
     <!-- Content Packages -->
-    <reference-content.version>1.1.1</reference-content.version>
+    <reference-content.version>1.1.2-SNAPSHOT</reference-content.version>
     <reference-demo-content.version>1.2.0-SNAPSHOT</reference-demo-content.version>
   </properties>
 

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -56,7 +56,7 @@
     <billing.version>1.2.0</billing.version>
     <!-- Content Packages -->
     <reference-content.version>1.1.1</reference-content.version>
-    <reference-demo-content.version>1.1.0</reference-demo-content.version>
+    <reference-demo-content.version>1.2.0-SNAPSHOT</reference-demo-content.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This PR bumps the version of the content packages to their latest snapshot versions so that PRs such as https://github.com/openmrs/openmrs-content-referenceapplication/pull/2 would be included in dev3.