### PR TITLE
(chore) persist maven cache between builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ COPY pom.xml ./
 COPY distro ./distro/
 
 # Build the distro, but only deploy from the amd64 build
-RUN --mount=type=secret,id=m2settings,target=/usr/share/maven/ref/settings-docker.xml if [[ "$MVN_ARGS" != "deploy" || "$(arch)" = "x86_64" ]]; then mvn $MVN_ARGS_SETTINGS $MVN_ARGS; else mvn $MVN_ARGS_SETTINGS install; fi
+RUN --mount=type=secret,id=m2settings,target=/usr/share/maven/ref/settings-docker.xml \
+    --mount=type=cache,id=m2cache,target=/usr/share/maven/ref/repository \
+    if [[ "$MVN_ARGS" != "deploy" || "$(arch)" = "x86_64" ]]; \
+    then mvn $MVN_ARGS_SETTINGS $MVN_ARGS; \
+    else mvn $MVN_ARGS_SETTINGS install; \
+    fi
 
 RUN cp /openmrs_distro/distro/target/sdk-distro/web/openmrs_core/openmrs.war /openmrs/distribution/openmrs_core/
 
@@ -22,7 +27,9 @@ RUN cp -R /openmrs_distro/distro/target/sdk-distro/web/openmrs_owas /openmrs/dis
 RUN cp -R /openmrs_distro/distro/target/sdk-distro/web/openmrs_config /openmrs/distribution/openmrs_config/
 
 # Clean up after copying needed artifacts
-RUN mvn $MVN_ARGS_SETTINGS clean
+RUN --mount=type=secret,id=m2settings,target=/usr/share/maven/ref/settings-docker.xml \
+    --mount=type=cache,id=m2cache,target=/usr/share/maven/ref/repository \
+    mvn $MVN_ARGS_SETTINGS clean
 
 ### Run Stage
 # Replace 'nightly' with the exact version of openmrs-core built for production (if available)


### PR DESCRIPTION
Mounting the /usr/share/maven/ref/repository directory as a cache means that the m2 cache is preserved between subsequent invocations of `docker compose build`, thus eliminating the need to re-download all the maven packages and openmrs modules. (SNAPSHOT versions of packages will still always be downloaded.)

In a development environment, this can greatly speed up docker builds when trying out changes to the distro.

Incidentally, applying the same mounts to both the `mvn install` and `mvn clean` commands, for consistency.