### PR TITLE
Remove the Provider Management Module

### DIFF
--- a/package/src/main/resources/openmrs-distro.properties
+++ b/package/src/main/resources/openmrs-distro.properties
@@ -9,7 +9,6 @@ omod.registrationapp=${registrationappVersion}
 omod.idgen=${idgenVersion}
 omod.emrapi=${emrapiVersion}
 omod.spa=${spaVersion}
-omod.providermanagement=${providermanagementVersion}
 omod.uilibrary=${uilibraryVersion}
 omod.uicommons=${uicommonsVersion}
 omod.referenceapplication=${referenceapplicationVersion}

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
 		<idgenVersion>4.15.0-SNAPSHOT</idgenVersion>
 		<emrapiVersion>2.4.0-SNAPSHOT</emrapiVersion>
 		<referenceapplicationVersion>2.14.0-SNAPSHOT</referenceapplicationVersion>
-		<providermanagementVersion>2.17.0-SNAPSHOT</providermanagementVersion>
 		<uilibraryVersion>2.0.8-SNAPSHOT</uilibraryVersion>
 		<calculationVersion>1.3.1-SNAPSHOT</calculationVersion>
 		<serialization.xstreamVersion>0.2.17-SNAPSHOT</serialization.xstreamVersion>
@@ -254,12 +253,6 @@
                 <version>${emrapiVersion}</version>
 				<scope>provided</scope>
             </dependency>
-			<dependency>
-				<groupId>org.openmrs.module</groupId>
-				<artifactId>providermanagement-api</artifactId>
-				<version>${providermanagementVersion}</version>
-				<scope>provided</scope>
-			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>uilibrary-api</artifactId>
@@ -494,13 +487,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
-				<artifactId>providermanagement-api</artifactId>
-				<version>${providermanagementVersion}</version>
-				<classifier>tests</classifier>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.openmrs.module</groupId>
 				<artifactId>uilibrary-api</artifactId>
 				<version>${uilibraryVersion}</version>
 				<classifier>tests</classifier>
@@ -708,12 +694,6 @@
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>emrapi-omod</artifactId>
 				<version>${emrapiVersion}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.openmrs.module</groupId>
-				<artifactId>providermanagement-omod</artifactId>
-				<version>${providermanagementVersion}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Fixes the error below on the qa-refapp:
`openmrs-referenceapplication_1        | WARN - AbstractApplicationContext.refresh(591) |2025-06-13T18:05:33,573| Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.openmrs.module.spa.spring.SpaBeanPostProcessor#0' defined in URL [jar:file:/openmrs/data/.openmrs-lib-cache/spa/spa.jar!/webModuleApplicationContext.xml]: Initialization of bean failed; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.transaction.interceptor.TransactionAttributeSourceAdvisor#0' defined in class path resource [applicationContext-service.xml]: Cannot resolve reference to bean 'transactionInterceptor' while setting bean property 'transactionInterceptor'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'transactionInterceptor' defined in class path resource [applicationContext-service.xml]: Cannot resolve reference to bean 'transactionManager' while setting bean property 'transactionManager'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'transactionManager' defined in class path resource [applicationContext-service.xml]: Cannot resolve reference to bean 'sessionFactory' while setting bean property 'sessionFactory'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'sessionFactory' defined in class path resource [applicationContext-service.xml]: Invocation of init method failed; nested exception is org.hibernate.DuplicateMappingException: The [org.openmrs.module.providermanagement.ProviderRole] and [org.openmrs.ProviderRole] entities share the same JPA entity name: [ProviderRole] which is not allowed!`