### PR TITLE
(chore) Upgrade Node.js to 22 in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@
 #--------------------------------------------
 # Dev Stage - Assembles and Builds Frontend
 #--------------------------------------------
-FROM --platform=$BUILDPLATFORM node:18-alpine as dev
+FROM --platform=$BUILDPLATFORM node:22-alpine as dev
 
 ARG APP_SHELL_VERSION=next
 


### PR DESCRIPTION
Updates the development stage base image from Node.js 18 to Node.js 22 to align with the latest changes in Core. Also fixes this issue:

![CleanShot 2025-06-16 at 20 11 58@2x](https://github.com/user-attachments/assets/ab68df0e-b48b-4f1f-afc1-602532e6b789)
