### PR TITLE
Switch qa-ref2app to run against platform 2.8.0-alpha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<openMRSVersion>2.8.0-SNAPSHOT</openMRSVersion>
+		<openMRSVersion>2.8.0-alpha</openMRSVersion>
 		<referencemetadataVersion>2.14.0-SNAPSHOT</referencemetadataVersion>
 		<appframeworkVersion>2.19.0-SNAPSHOT</appframeworkVersion>
 		<uiframeworkVersion>4.0.1-SNAPSHOT</uiframeworkVersion>


### PR DESCRIPTION
Switch qa-ref2app to run against platform 2.8.0-alpha release.