### PR TITLE
Bump authentication module to 2.0.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -38,7 +38,7 @@
     <appointments.version>2.1.0-20250318.070530-1</appointments.version>
     <teleconsultation.version>2.1.0-20250318.154145-1</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>
-    <authentication.version>1.1.0</authentication.version>
+    <authentication.version>2.0.0-SNAPSHOT</authentication.version>
     <reporting.version>1.28.0</reporting.version>
     <reportingrest.version>1.15.0</reportingrest.version>
     <!-- the next three are required for reporting -->


### PR DESCRIPTION
New auth version includes [fix](https://openmrs.atlassian.net/browse/AUT-9) to have REST api calls return 401 on user logout. This allows us to better handle frontend redirecting to login page on user idle logout.