### PR TITLE
Bump FHIR2 to 2.8.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -25,7 +25,7 @@
          we do so here so that we can utilise Maven to track updates, etc. -->
     <openmrs.version>2.7.5-SNAPSHOT</openmrs.version>
     <initializer.version>2.9.0</initializer.version>
-    <fhir2.version>2.6.0-SNAPSHOT</fhir2.version>
+    <fhir2.version>2.8.0-SNAPSHOT</fhir2.version>
     <webservices.rest.version>2.50.0-SNAPSHOT</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
     <idgen.version>4.14.0</idgen.version>


### PR DESCRIPTION
Bump FHIR2 to 2.8.0-SNAPSHOT to get the latest changes that is required for the immunization project. 
Specifically this one: https://github.com/openmrs/openmrs-module-fhir2/pull/574

