### PR TITLE
Bump queue module to version 2.8.0

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -34,7 +34,7 @@
     <openconceptlab.version>2.4.0</openconceptlab.version>
     <attachments.version>3.7.0</attachments.version>
     <referencedemodata.version>2.5.0</referencedemodata.version>
-    <queue.version>2.7.0-SNAPSHOT</queue.version>
+    <queue.version>2.8.0</queue.version>
     <appointments.version>2.1.0-20250318.070530-1</appointments.version>
     <teleconsultation.version>2.1.0-20250318.154145-1</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>


### PR DESCRIPTION
**Description of what changed**
I bump queue module from 2.7.0-SNAPSHOT to 2.8.0-SNAPSHOT Since version 2.7.0 has been released.