### PR TITLE
(fix) Remove stale and redundant config from config-core_demo.json

### DIFF
--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -14,32 +14,5 @@
         "add": ["order-basket-action-menu"]
       }
     }
-  },
-  "@openmrs/esm-service-queues-app": {
-    "statusConfigs": [
-      {
-        "conceptUuid": "51ae5e4d-b72b-4912-bf31-a17efb690aeb",
-        "iconComponent": "InProgress"
-      },
-      {
-        "conceptUuid": "ca7494ae-437f-4fd0-8aae-b88b9a2ba47d",
-        "iconComponent": "Group"
-      },
-      {
-        "conceptUuid": "b559fb77-4e1e-4285-b9b7-1d03e0ba983f",
-        "iconComponent": "Group"
-      }
-    ],
-    "concepts": {
-      "defaultPriorityConceptUuid": "f4620bfa-3625-4883-bd3f-84c2cce14470",
-      "emergencyPriorityConceptUuid": "04f6f7e0-e3cb-4e13-a133-4479f759574e",
-      "defaultStatusConceptUuid": "51ae5e4d-b72b-4912-bf31-a17efb690aeb",
-      "defaultTransitionStatus": "ca7494ae-437f-4fd0-8aae-b88b9a2ba47d"
-    },
-    "visitQueueNumberAttributeUuid": "",
-    "defaultFacilityUrl": ""
-  },
-  "@openmrs/esm-styleguide": {
-    "Brand color #1": "#005d5d"
   }
 }

--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -14,5 +14,8 @@
         "add": ["order-basket-action-menu"]
       }
     }
+  },
+  "@openmrs/esm-styleguide": {
+    "Brand color #1": "#005d5d"
   }
 }


### PR DESCRIPTION
## Summary

The `@openmrs/esm-service-queues-app` config block in `config-core_demo.json` contains keys that are either absent from the current config schema (`defaultFacilityUrl`), at the wrong nesting level (`statusConfigs`), or that simply restate schema defaults (`concepts`, `visitQueueNumberAttributeUuid`). These produce hundreds of `Unknown config key` console errors on every page load, drowning out real errors.

The `@openmrs/esm-styleguide` block sets `Brand color #1` to `#005d5d`, which is already the schema default — a no-op.

This PR removes both blocks, keeping only the `@openmrs/esm-patient-chart-app` and `@openmrs/esm-ward-app` entries that actually override defaults.

## Screenshots

### Before — console errors on every page load
Every navigation triggers 24 `Unknown config key` error-level messages (4 keys × 6 repetitions):

```
[error] Unknown config key '@openmrs/esm-service-queues-app.statusConfigs' provided. Ignoring.
[error] Unknown config key '@openmrs/esm-service-queues-app.concepts' provided. Ignoring.
[error] Unknown config key '@openmrs/esm-service-queues-app.visitQueueNumberAttributeUuid' provided. Ignoring.
[error] Unknown config key '@openmrs/esm-service-queues-app.defaultFacilityUrl' provided. Ignoring.
```

### After
No `Unknown config key` errors in the console.