### PR TITLE
(chore) Upgrade nginx from 1.25 to 1.28 in frontend and gateway

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,7 @@ RUN if [ ! -f ./spa/index.html ]; then echo 'Build failed. Please check the logs
 #--------------------------------------------
 # Runtime Stage - Published Image
 #--------------------------------------------
-FROM nginx:1.25-alpine
+FROM nginx:1.28-alpine
 
 RUN apk update && \
     apk upgrade && \

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM nginx:1.25-alpine
+FROM nginx:1.28-alpine
 
 ENV FRAME_ANCESTORS ""
 


### PR DESCRIPTION
## Summary

- Upgrades the nginx base image from `1.25-alpine` to `1.28-alpine` in both `frontend/Dockerfile` and `gateway/Dockerfile`
- nginx 1.25 has been EOL since May 2024 and receives no security patches
- 1.28 is the current stable branch

## Compatibility

All directives used in the frontend and gateway nginx configs are stable across 1.25→1.28:

| Directive | Status |
|---|---|
| `http2 on;` | Already uses the new syntax (introduced in 1.25.1) |
| `proxy_cookie_flags` | Stable since 1.19.8 |
| `map`, `upstream`, `gzip_*`, `resolver` | No breaking changes |
| Docker entrypoint template processing (`/etc/nginx/templates/`) | Unchanged |

The only default behavior change is TLSv1/1.1 being disabled by default (since 1.27), which is a security improvement. The SSL config defers protocol settings to certbot's `options-ssl-nginx.conf`, so this is a no-op in practice.