### PR TITLE
(chore) Bump demo content package to 1.8.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -57,7 +57,7 @@
     <billing.version>2.2.0</billing.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
-    <reference-demo-content.version>1.7.0</reference-demo-content.version>
+    <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary

Bumps `reference-demo-content.version` from `1.7.0` to `1.8.0-SNAPSHOT` to pick up criteria-based BMI reference ranges added in openmrs/openmrs-content-referenceapplication-demo#63.