### PR TITLE
Bump REST module to 3.4.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -26,7 +26,7 @@
     <openmrs.version>2.8.6</openmrs.version>
     <initializer.version>2.11.0</initializer.version>
     <fhir2.version>3.1.0-SNAPSHOT</fhir2.version>
-    <webservices.rest.version>3.3.0-SNAPSHOT</webservices.rest.version>
+    <webservices.rest.version>3.4.0-SNAPSHOT</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
     <patientdocuments.version>1.1.0-SNAPSHOT</patientdocuments.version>
     <idgen.version>5.0.4</idgen.version>


### PR DESCRIPTION
I mostly want Obs's new `previousVersions` property to be included. See: https://github.com/openmrs/openmrs-module-webservices.rest/pull/732 