### PR TITLE
Add a job to deploy distro-emr-frontend

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -78,6 +78,12 @@ jobs:
           
           docker rm $CONTAINER_ID
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
       - name: Create Maven settings.xml
         run: |
           mkdir -p "$HOME/.m2"
@@ -100,12 +106,6 @@ jobs:
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
           MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
 
       - name: Deploy frontend artifact
         run: mvn deploy -Pfrontend -pl frontend -s $HOME/.m2/settings.xml -B

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -61,3 +61,51 @@ jobs:
             ${{ env.IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
             ${{ env.IMAGE }}:${{ env.DOCKER_IMAGE_TAG_VERSION }}
             ${{ env.IMAGE }}:${{ env.DOCKER_IMAGE_TAG_ENV }}
+
+  extract-and-deploy:
+    name: Extract config and Deploy to Maven
+    runs-on: ubuntu-latest
+    needs: build-and-publish
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract spa-assemble-config.json
+        run: |
+          IMAGE="${{ env.IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}"
+          CONTAINER_ID=$(docker create $IMAGE)
+          
+          docker cp $CONTAINER_ID:/usr/share/nginx/html/spa-assemble-config.json ./frontend/src/main/resources/spa-assemble-config.json
+          
+          docker rm $CONTAINER_ID
+
+      - name: Create Maven settings.xml
+        run: |
+          mkdir -p "$HOME/.m2"
+          cat > "$HOME/.m2/settings.xml" << EOF
+          <settings>
+            <servers>
+              <server>
+                <id>openmrs-repo-releases</id>
+                <username>${MAVEN_REPO_USERNAME}</username>
+                <password>${MAVEN_REPO_API_KEY}</password>
+              </server>
+              <server>
+                <id>openmrs-repo-snapshots</id>
+                <username>${MAVEN_REPO_USERNAME}</username>
+                <password>${MAVEN_REPO_API_KEY}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+        env:
+          MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
+          MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Deploy frontend artifact
+        run: mvn deploy -Pfrontend -B

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -108,4 +108,4 @@ jobs:
           java-version: '17'
 
       - name: Deploy frontend artifact
-        run: mvn deploy -Pfrontend -B
+        run: mvn deploy -Pfrontend -pl frontend -am -s $HOME/.m2/settings.xml -B

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -108,4 +108,4 @@ jobs:
           java-version: '17'
 
       - name: Deploy frontend artifact
-        run: mvn deploy -Pfrontend -pl frontend -am -s $HOME/.m2/settings.xml -B
+        run: mvn deploy -Pfrontend -pl frontend -s $HOME/.m2/settings.xml -B

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
 
       - name: Create Maven settings.xml
         run: |

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-publish
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Extract spa-assemble-config.json
         run: |
@@ -77,7 +77,7 @@ jobs:
           docker rm $CONTAINER_ID
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '21'

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -73,9 +73,7 @@ jobs:
         run: |
           IMAGE="${{ env.IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}"
           CONTAINER_ID=$(docker create $IMAGE)
-          
           docker cp $CONTAINER_ID:/usr/share/nginx/html/spa-assemble-config.json ./frontend/src/main/resources/spa-assemble-config.json
-          
           docker rm $CONTAINER_ID
 
       - name: Set up Java


### PR DESCRIPTION
We previously ran this job in Bamboo: https://ci.openmrs.org/browse/O3-PFA

After moving things to GitHub Actions, this step was missed.

This PR adds it back as a separate job in the build-frontend workflow.

Tested it here: https://github.com/openmrs/openmrs-distro-referenceapplication/actions/runs/25336409464/job/74283049212


Based on: https://openmrs.slack.com/archives/CHP5QAE5R/p1777913511355159