### PR TITLE
Update emrapi version to 3.4.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -49,7 +49,7 @@
     <ordertemplates.version>2.2.0</ordertemplates.version>
     <patientflags.version>3.0.10</patientflags.version>
     <o3forms.version>2.3.0</o3forms.version>
-    <emrapi.version>3.3.0</emrapi.version>
+    <emrapi.version>3.4.0-SNAPSHOT</emrapi.version>
     <event.version>4.0.0</event.version>
     <bedmanagement.version>7.2.0</bedmanagement.version>
     <!-- Stock Management and Billing -->


### PR DESCRIPTION
The endpoints and changes that needed for the Procedure history feature is on the snapshot version of the EMR API. We need those to move forward. 