### PR TITLE
(fix) Strip /openmrs/spa/ prefix when proxying to frontend

### DIFF
--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -64,7 +64,8 @@ server {
   resolver 127.0.0.11 valid=30s ipv6=off;
 
   location /openmrs/spa/ {
-    set $frontend http://frontend/;
+    set $frontend http://frontend;
+    rewrite ^/openmrs/spa/(.*) /$1 break;
     proxy_pass $frontend;
   }
 


### PR DESCRIPTION
Dev3's currently renders a blank page on initial load. The page HTML loads, but every asset the SPA needs (JS bundle, import map, CSS, config) comes back as HTML instead of the file the browser asked for. With `nosniff` set, the browser refuses to run the bundle as JavaScript and the app never starts.

7d23e1ec moved the gateway to look up the frontend's IP at request time, which meant switching `proxy_pass` to use a variable. That has a hidden side effect: with a variable, nginx no longer strips the matched location prefix automatically. So `/openmrs/spa/main.js` was reaching the frontend as `/openmrs/spa/main.js` instead of `/main.js`, the file wasn't there, and a catch-all served `index.html` for everything.

7ff99dd8 tried fixing this by moving the trailing slash around, but hit the same nginx behaviour. Confirmed by running the published gateway and frontend images together locally, where every request arrived at the frontend as bare `/`.

This PR tries to fix it by adding an explicit `rewrite` so the prefix stripping happens whether `proxy_pass` is using a variable or not:

```nginx
location /openmrs/spa/ {
  set $frontend http://frontend;
  rewrite ^/openmrs/spa/(.*) /$1 break;
  proxy_pass $frontend;
}
```

It maintains the runtime DNS work from 7d23e1ec, just makes the prefix stripping explicit.

I've tried to verify it works by building the patched gateway locally and running it against the published frontend image. The JS bundle, import map, CSS, and config serve with the right content types. SPA routes like `/openmrs/spa/login` still fall through to `index.html`. Missing files return 404.