### PR TITLE
(chore) Bump billing module to 2.3.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -54,7 +54,7 @@
     <bedmanagement.version>7.2.0</bedmanagement.version>
     <!-- Stock Management and Billing -->
     <stockmanagement.version>3.0.0</stockmanagement.version>
-    <billing.version>2.2.0</billing.version>
+    <billing.version>2.3.0-SNAPSHOT</billing.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>


### PR DESCRIPTION
Bumps the billing module version in the distro from 2.2.0 to 2.3.0-SNAPSHOT to get the latest changes in the billing module into dev3