### PR TITLE
Add task-list backend and frontend modules to the distro

### DIFF
--- a/distro/distro-no-demo.properties
+++ b/distro/distro-no-demo.properties
@@ -33,4 +33,5 @@ omod.event=${event.version}
 omod.bedmanagement=${bedmanagement.version}
 omod.stockmanagement=${stockmanagement.version}
 omod.billing=${billing.version}
+omod.tasks=${tasks.version}
 content.referenceapplication=${reference-content.version}

--- a/distro/distro.properties
+++ b/distro/distro.properties
@@ -34,5 +34,6 @@ omod.event=${event.version}
 omod.bedmanagement=${bedmanagement.version}
 omod.stockmanagement=${stockmanagement.version}
 omod.billing=${billing.version}
+omod.tasks=${tasks.version}
 content.referenceapplication=${reference-content.version}
 content.referenceapplication-demo=${reference-demo-content.version}

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -55,6 +55,7 @@
     <!-- Stock Management and Billing -->
     <stockmanagement.version>3.0.0</stockmanagement.version>
     <billing.version>2.2.0</billing.version>
+    <tasks.version>1.0.0-SNAPSHOT</tasks.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
@@ -236,6 +237,12 @@
       <groupId>org.openmrs.module</groupId>
       <artifactId>billing-omod</artifactId>
       <version>${billing.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openmrs.module</groupId>
+      <artifactId>tasks-omod</artifactId>
+      <version>${tasks.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/frontend/spa-assemble-config.json
+++ b/frontend/spa-assemble-config.json
@@ -41,6 +41,7 @@
     "@openmrs/esm-service-queues-app": "next",
     "@openmrs/esm-stock-management-app": "next",
     "@openmrs/esm-system-admin-app": "next",
+    "@openmrs/esm-task-list-app": "next",
     "@openmrs/esm-user-onboarding-app": "next",
     "@openmrs/esm-ward-app": "next"
   },


### PR DESCRIPTION
Adds the task-list feature to the reference application distro by including both the backend OMOD (`tasks-omod`) and the frontend ESM (`@openmrs/esm-task-list-app`).

### Backend (`distro/`)

- `pom.xml`: declare `tasks.version` property (`1.0.0-SNAPSHOT`) and add a `tasks-omod` dependency under `org.openmrs.module`.
- `distro.properties` and `distro-no-demo.properties`: add `omod.tasks=${tasks.version}` so the SDK build picks up the OMOD.

### Frontend

- `frontend/spa-assemble-config.json`: add `@openmrs/esm-task-list-app` to the `frontendModules` map, pinned to `next` to match the convention used by every other module here.

### Notes

- `tasks-omod` is currently `1.0.0-SNAPSHOT` — no release has been published yet. CI will need the SNAPSHOT artifact available on `mavenrepo.openmrs.org/snapshots`, or this should be repinned to a release once one is cut.
- The frontend ESM resolves via the import-map service against the `next` dist-tag, same as every other module in this file.
- Context: this came up while looking at why the task-list e2e tests in [openmrs-esm-patient-chart#3303](https://github.com/openmrs/openmrs-esm-patient-chart/pull/3303) were failing — the feature isn't loaded in that repo's e2e env either. Adding task-list here doesn't fix that PR (patient-chart builds its own e2e image), but it does make task-list a first-class part of the refapp.