### PR TITLE
(fix) Use task list backend snapshot

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -55,7 +55,7 @@
     <!-- Stock Management and Billing -->
     <stockmanagement.version>3.0.0</stockmanagement.version>
     <billing.version>2.3.0-SNAPSHOT</billing.version>
-    <tasks.version>1.0.0</tasks.version>
+    <tasks.version>1.1.0-SNAPSHOT</tasks.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>


### PR DESCRIPTION
## Summary

Updates the reference application distro to include `tasks-omod` `1.1.0-SNAPSHOT`. Reviewing `openmrs-module-tasks` showed that this snapshot supports the patient task list app rationale payload in `activity.detail.reasonCode`, so it is the backend version needed by the current task-list app contract.

This pairs with openmrs/openmrs-esm-patient-chart#3316, which lowers the task-list app dependency from the unreleased `tasks >=2.0.0` requirement to `tasks >=1.1.0-SNAPSHOT`. Once the backend image rebuilds with this distro change, openmrs/openmrs-esm-core#1779 can add `@openmrs/esm-patient-task-list-app` to the core E2E environment without implementer tools reporting unresolved backend dependencies.
