### PR TITLE
Add auditlogweb module and enable Hibernate Envers

### DIFF
--- a/distro/distro-no-demo.properties
+++ b/distro/distro-no-demo.properties
@@ -34,4 +34,5 @@ omod.bedmanagement=${bedmanagement.version}
 omod.stockmanagement=${stockmanagement.version}
 omod.billing=${billing.version}
 omod.tasks=${tasks.version}
+omod.auditlogweb=${auditlogweb.version}
 content.referenceapplication=${reference-content.version}

--- a/distro/distro.properties
+++ b/distro/distro.properties
@@ -35,5 +35,6 @@ omod.bedmanagement=${bedmanagement.version}
 omod.stockmanagement=${stockmanagement.version}
 omod.billing=${billing.version}
 omod.tasks=${tasks.version}
+omod.auditlogweb=${auditlogweb.version}
 content.referenceapplication=${reference-content.version}
 content.referenceapplication-demo=${reference-demo-content.version}

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -56,6 +56,7 @@
     <stockmanagement.version>3.0.0</stockmanagement.version>
     <billing.version>2.3.0-SNAPSHOT</billing.version>
     <tasks.version>1.0.0</tasks.version>
+    <auditlogweb.version>1.1.0-SNAPSHOT</auditlogweb.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>
@@ -243,6 +244,12 @@
       <groupId>org.openmrs.module</groupId>
       <artifactId>tasks-omod</artifactId>
       <version>${tasks.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openmrs.module</groupId>
+      <artifactId>auditlogweb-omod</artifactId>
+      <version>${auditlogweb.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/docker-compose-no-volumes.yml
+++ b/docker-compose-no-volumes.yml
@@ -13,6 +13,8 @@ services:
       OMRS_CONFIG_CONNECTION_DATABASE: openmrs
       OMRS_CONFIG_CONNECTION_USERNAME: ${OPENMRS_DB_USER:-openmrs}
       OMRS_CONFIG_CONNECTION_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
+      OMRS_EXTRA_HIBERNATE_INTEGRATION_ENVERS_ENABLED: "true"
+      OMRS_EXTRA_HIBERNATE_HBM2DDL_AUTO: "update"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       OMRS_CONFIG_CONNECTION_DATABASE: openmrs
       OMRS_CONFIG_CONNECTION_USERNAME: ${OMRS_DB_USER:-openmrs}
       OMRS_CONFIG_CONNECTION_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
+      OMRS_EXTRA_HIBERNATE_INTEGRATION_ENVERS_ENABLED: "true"
+      OMRS_EXTRA_HIBERNATE_HBM2DDL_AUTO: "update"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s


### PR DESCRIPTION
  - Add auditlogweb-omod 1.1.0-SNAPSHOT to distro/pom.xml, distro.properties, and distro-no-demo.properties
  - Set hibernate.integration.envers.enabled=true and hibernate.hbm2ddl.auto=update via OMRS_EXTRA_* env vars in docker-compose.yml and docker-compose-no-volumes.yml

This is required for the auditlog frontend GSOC project.