### PR TITLE
fix: Use tasks snapshot with care plan endpoint fix

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -55,7 +55,7 @@
     <!-- Stock Management and Billing -->
     <stockmanagement.version>3.0.0</stockmanagement.version>
     <billing.version>2.3.0-SNAPSHOT</billing.version>
-    <tasks.version>2.0.0</tasks.version>
+    <tasks.version>2.1.0-SNAPSHOT</tasks.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.8.0-SNAPSHOT</reference-demo-content.version>


### PR DESCRIPTION
Updates the reference application distro to use `tasks-omod` `2.1.0-SNAPSHOT`.

The current `2.0.0` artifact registers the care plan controller, but maps it under `/ws/rest/v1/tasks/careplan`. Because OpenMRS already mounts the REST servlet under `/ws/*`, the endpoint becomes reachable as `/openmrs/ws/ws/rest/v1/tasks/careplan` instead of the frontend/e2e URL `/openmrs/ws/rest/v1/tasks/careplan`.

The latest tasks snapshot changes the controller mapping to `/rest/v1/tasks/careplan`, which should expose the endpoint at the expected URL and unblock the patient-chart task-list e2e tests.

Validation:

- Verified the failing e2e logs contain 404s for `/openmrs/ws/rest/v1/tasks/careplan`.
- Verified the current backend responds at `/openmrs/ws/ws/rest/v1/tasks/careplan`, proving the controller is registered but mounted under the doubled `/ws` path.
- Verified the latest `tasks-omod` snapshot contains the corrected `/rest/v1/tasks/careplan` mapping.
- Ran `git diff --check`.