### PR TITLE
Webhook

### DIFF
--- a/.github/workflows/openmrs-webhook-module-ci.yml
+++ b/.github/workflows/openmrs-webhook-module-ci.yml
@@ -1,0 +1,28 @@
+name: OpenMRS Webhook Module CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  openmrs-webhook-module:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Test webhook module
+        run: mvn -pl openmrs-webhook-module test
+
+      - name: Package LU1 distro metadata
+        run: mvn -P distro -DskipTests package
+
+      - name: Secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 **/.DS_Store
 **/node_modules/
 .idea/
+.git
+.env
+
 
 # LLM coding agent documentation
 CLAUDE.md
@@ -10,3 +13,4 @@ CLAUDE.md
 .cursor/
 .aider*
 .clinerules
+

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+[allowlist]
+description = "Allow OpenMRS demo defaults and documentation examples"
+paths = [
+  '''README\.md$''',
+  '''docker-compose.*\.yml$''',
+  '''tests/.*''',
+  '''openmrs-webhook-module/README\.md$'''
+]
+regexes = [
+  '''openmrs''',
+  '''admin@example\.com''',
+  '''your-domain\.com''',
+  '''example\.com'''
+]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ This distribution consists of four images:
 - **gateway** - This image is an nginx reverse proxy that sits in front of the `backend` and `frontend` containers
   and provides a common interface to both. This helps mitigate CORS issues.
 
+## Appointment webhook module
+
+This workspace also contains `openmrs-webhook-module`, a Maven-built OpenMRS event-listener module. It subscribes to `Encounter` events through the OpenMRS Event Module and posts signed appointment webhooks to the communication-module backend.
+
+Run its tests with:
+
+```bash
+mvn -pl openmrs-webhook-module test
+```
+
+Required OpenMRS global properties:
+
+| Property | Description |
+|---|---|
+| `openmrswebhook.backendUrl` | Backend endpoint, for example `http://host.docker.internal:5111/api/webhooks/openmrs/appointments` |
+| `openmrswebhook.secret` | Shared HMAC secret, same value as backend `OPENMRS_WEBHOOK_SECRET` |
+| `openmrswebhook.organizationId` | Tenant/organization id sent to the backend |
+| `openmrswebhook.outboxPath` | Optional retry outbox file path |
+
 When running with SSL enabled (using `docker-compose.ssl.yml`), an additional service is included:
 
 - **certbot** - This image is used for generating and renewing SSL certificates (Let's Encrypt or self-signed)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - frontend
       - backend
     ports:
-      - "80:80"
+      - "3032:80"
 
   frontend:
     image: openmrs/openmrs-reference-application-3-frontend:${TAG:-qa}
@@ -35,9 +35,12 @@ services:
       OMRS_CONFIG_CONNECTION_DATABASE: openmrs
       OMRS_CONFIG_CONNECTION_USERNAME: ${OMRS_DB_USER:-openmrs}
       OMRS_CONFIG_CONNECTION_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
+      OMRS_DEV_DEBUG_PORT: "5005"   # Debug enabled
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s
+    ports:
+      - "5005:5005"                 # Expose debug port
     volumes:
       - openmrs-data:/openmrs/data
 

--- a/openmrs-webhook-module/README.md
+++ b/openmrs-webhook-module/README.md
@@ -1,0 +1,14 @@
+# OpenMRS Appointment Webhook Module
+
+Deze module luistert naar OpenMRS Event Module events voor `Encounter`-records en stuurt afspraak-events naar de communicatiemodule-backend.
+
+Runtime-configuratie gebeurt via OpenMRS global properties:
+
+| Property | Betekenis |
+|---|---|
+| `openmrswebhook.backendUrl` | Volledige backend endpoint URL, bijvoorbeeld `http://host.docker.internal:5111/api/webhooks/openmrs/appointments` |
+| `openmrswebhook.secret` | Gedeeld HMAC-secret voor `X-OpenMRS-Signature` |
+| `openmrswebhook.organizationId` | Tenant-/organisatie-id die in `X-OpenMRS-Organization-Id` wordt meegestuurd |
+| `openmrswebhook.outboxPath` | Optioneel pad voor retry-outbox, standaard `openmrs-webhook-outbox.jsonl` |
+
+Het modulepakket gebruikt reflectie voor `org.openmrs.event.Event.subscribe(...)`, zodat de code testbaar blijft zonder directe compile-time dependency op de Event Module API. De LU1 distro bevat `event-omod` al.

--- a/openmrs-webhook-module/pom.xml
+++ b/openmrs-webhook-module/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openmrs</groupId>
+    <artifactId>distro-emr</artifactId>
+    <version>3.7.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>openmrs-webhook-module</artifactId>
+  <name>OpenMRS Appointment Webhook Module</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <junit.version>5.11.4</junit.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openmrs</groupId>
+      <artifactId>openmrs-api</artifactId>
+      <version>2.8.6</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.jms</groupId>
+      <artifactId>javax.jms-api</artifactId>
+      <version>2.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/AppointmentEventListener.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/AppointmentEventListener.java
@@ -1,0 +1,71 @@
+package org.openmrs.module.openmrswebhook;
+
+import java.time.Instant;
+import java.util.UUID;
+import javax.jms.JMSException;
+import javax.jms.MapMessage;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+
+public class AppointmentEventListener implements MessageListener {
+    private final AppointmentWebhookDispatcher dispatcher;
+
+    public AppointmentEventListener(AppointmentWebhookDispatcher dispatcher) {
+        this.dispatcher = dispatcher;
+    }
+
+    @Override
+    public void onMessage(Message message) {
+        if (!(message instanceof MapMessage mapMessage)) {
+            return;
+        }
+
+        try {
+            String eventType = valueOrDefault(mapMessage, "action", "UPDATED");
+            String encounterId = firstPresent(mapMessage, "uuid", "encounterUuid", "resourceUuid");
+            String patientId = firstPresent(mapMessage, "patientUuid", "patientId", "subjectUuid");
+            String status = valueOrDefault(mapMessage, "status", "planned");
+            String start = valueOrDefault(mapMessage, "start", Instant.now().toString());
+            String eventId = valueOrDefault(mapMessage, "eventId", UUID.randomUUID().toString());
+
+            if (encounterId == null || patientId == null) {
+                return;
+            }
+
+            var payload = new AppointmentWebhookPayload(
+                encounterId,
+                patientId,
+                start,
+                optional(mapMessage, "end"),
+                status,
+                optional(mapMessage, "patientDisplay"),
+                optional(mapMessage, "serviceType"),
+                optional(mapMessage, "location"),
+                optional(mapMessage, "instructions")
+            );
+
+            dispatcher.dispatch(eventId, eventType, payload);
+        } catch (Exception ex) {
+            dispatcher.queueFailure("listener-error", "UPDATED", "{}");
+        }
+    }
+
+    private static String firstPresent(MapMessage message, String... keys) throws JMSException {
+        for (String key : keys) {
+            var value = optional(message, key);
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String valueOrDefault(MapMessage message, String key, String defaultValue) throws JMSException {
+        var value = optional(message, key);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private static String optional(MapMessage message, String key) throws JMSException {
+        return message.itemExists(key) ? message.getString(key) : null;
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/AppointmentWebhookDispatcher.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/AppointmentWebhookDispatcher.java
@@ -1,0 +1,59 @@
+package org.openmrs.module.openmrswebhook;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+
+public class AppointmentWebhookDispatcher {
+    private final AppointmentWebhookProperties properties;
+    private final HmacSigner signer;
+    private final WebhookOutbox outbox;
+    private final HttpClient httpClient;
+
+    public AppointmentWebhookDispatcher(
+            AppointmentWebhookProperties properties,
+            HmacSigner signer,
+            WebhookOutbox outbox,
+            HttpClient httpClient) {
+        this.properties = properties;
+        this.signer = signer;
+        this.outbox = outbox;
+        this.httpClient = httpClient;
+    }
+
+    public void dispatch(String eventId, String eventType, AppointmentWebhookPayload payload) {
+        String body = payload.toJson();
+        try {
+            send(eventId, eventType, body);
+        } catch (Exception ex) {
+            outbox.enqueue(new WebhookOutboxEntry(eventId, eventType, body, Instant.now()));
+        }
+    }
+
+    public void queueFailure(String eventId, String eventType, String body) {
+        outbox.enqueue(new WebhookOutboxEntry(eventId, eventType, body, Instant.now()));
+    }
+
+    public boolean send(String eventId, String eventType, String body) throws IOException, InterruptedException {
+        var timestamp = Instant.now().toString();
+        var signature = signer.sign(timestamp, body, properties.secret());
+        var request = HttpRequest.newBuilder(URI.create(properties.backendUrl()))
+            .header("Content-Type", "application/json")
+            .header("X-OpenMRS-Event-Id", eventId)
+            .header("X-OpenMRS-Event-Type", eventType)
+            .header("X-OpenMRS-Timestamp", timestamp)
+            .header("X-OpenMRS-Organization-Id", properties.organizationId())
+            .header("X-OpenMRS-Signature", "sha256=" + signature)
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+
+        var response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        if (response.statusCode() < 200 || response.statusCode() > 299) {
+            throw new IOException("Backend webhook returned HTTP " + response.statusCode());
+        }
+        return true;
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/AppointmentWebhookPayload.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/AppointmentWebhookPayload.java
@@ -1,0 +1,35 @@
+package org.openmrs.module.openmrswebhook;
+
+public record AppointmentWebhookPayload(
+        String encounterId,
+        String patientId,
+        String start,
+        String end,
+        String status,
+        String patientDisplay,
+        String serviceType,
+        String location,
+        String instructions) {
+
+    public String toJson() {
+        return "{"
+            + "\"encounterId\":\"" + escape(encounterId) + "\","
+            + "\"patientId\":\"" + escape(patientId) + "\","
+            + "\"start\":\"" + escape(start) + "\","
+            + nullable("end", end) + ","
+            + "\"status\":\"" + escape(status) + "\","
+            + nullable("patientDisplay", patientDisplay) + ","
+            + nullable("serviceType", serviceType) + ","
+            + nullable("location", location) + ","
+            + nullable("instructions", instructions)
+            + "}";
+    }
+
+    private static String nullable(String name, String value) {
+        return "\"" + name + "\":" + (value == null ? "null" : "\"" + escape(value) + "\"");
+    }
+
+    private static String escape(String value) {
+        return value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/AppointmentWebhookProperties.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/AppointmentWebhookProperties.java
@@ -1,0 +1,20 @@
+package org.openmrs.module.openmrswebhook;
+
+import org.openmrs.api.context.Context;
+
+public record AppointmentWebhookProperties(
+        String backendUrl,
+        String secret,
+        String organizationId,
+        String outboxPath) {
+
+    public static AppointmentWebhookProperties fromOpenMrsGlobalProperties() {
+        var admin = Context.getAdministrationService();
+        return new AppointmentWebhookProperties(
+            admin.getGlobalProperty("openmrswebhook.backendUrl", ""),
+            admin.getGlobalProperty("openmrswebhook.secret", ""),
+            admin.getGlobalProperty("openmrswebhook.organizationId", "default"),
+            admin.getGlobalProperty("openmrswebhook.outboxPath", "openmrs-webhook-outbox.jsonl")
+        );
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/EventSubscriptionRegistrar.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/EventSubscriptionRegistrar.java
@@ -1,0 +1,21 @@
+package org.openmrs.module.openmrswebhook;
+
+import javax.jms.MessageListener;
+
+public class EventSubscriptionRegistrar {
+    private static final String[] ACTIONS = {"CREATED", "UPDATED", "VOIDED", "UNVOIDED"};
+
+    public void registerEncounterListener(MessageListener listener) {
+        try {
+            Class<?> eventClass = Class.forName("org.openmrs.event.Event");
+            Class<?> encounterClass = Class.forName("org.openmrs.Encounter");
+            var subscribe = eventClass.getMethod("subscribe", Class.class, String.class, MessageListener.class);
+
+            for (String action : ACTIONS) {
+                subscribe.invoke(null, encounterClass, action, listener);
+            }
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("OpenMRS Event Module subscription failed.", ex);
+        }
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/FileWebhookOutbox.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/FileWebhookOutbox.java
@@ -1,0 +1,65 @@
+package org.openmrs.module.openmrswebhook;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileWebhookOutbox implements WebhookOutbox {
+    private final Path path;
+
+    public FileWebhookOutbox(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public synchronized void enqueue(WebhookOutboxEntry entry) {
+        try {
+            Files.createDirectories(path.toAbsolutePath().getParent());
+            Files.writeString(
+                path,
+                entry.encode() + System.lineSeparator(),
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not persist OpenMRS webhook outbox entry.", ex);
+        }
+    }
+
+    @Override
+    public synchronized List<WebhookOutboxEntry> readAll() {
+        if (!Files.exists(path)) {
+            return List.of();
+        }
+
+        try {
+            var entries = new ArrayList<WebhookOutboxEntry>();
+            for (String line : Files.readAllLines(path, StandardCharsets.UTF_8)) {
+                if (!line.isBlank()) entries.add(WebhookOutboxEntry.decode(line));
+            }
+            return entries;
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not read OpenMRS webhook outbox.", ex);
+        }
+    }
+
+    @Override
+    public synchronized void replaceAll(List<WebhookOutboxEntry> entries) {
+        try {
+            Files.createDirectories(path.toAbsolutePath().getParent());
+            var lines = entries.stream().map(WebhookOutboxEntry::encode).toList();
+            Files.write(path, lines, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not rewrite OpenMRS webhook outbox.", ex);
+        }
+    }
+
+    public static WebhookOutboxEntry entry(String eventId, String eventType, String body) {
+        return new WebhookOutboxEntry(eventId, eventType, body, Instant.now());
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/HmacSigner.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/HmacSigner.java
@@ -1,0 +1,26 @@
+package org.openmrs.module.openmrswebhook;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+public class HmacSigner {
+    public String sign(String timestamp, String body, String secret) {
+        try {
+            var mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            var digest = mac.doFinal((timestamp + "." + body).getBytes(StandardCharsets.UTF_8));
+            return toHex(digest);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Could not sign OpenMRS webhook payload.", ex);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        var builder = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/OpenmrsWebhookActivator.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/OpenmrsWebhookActivator.java
@@ -1,0 +1,21 @@
+package org.openmrs.module.openmrswebhook;
+
+import java.net.http.HttpClient;
+import java.nio.file.Path;
+import org.openmrs.module.BaseModuleActivator;
+
+public class OpenmrsWebhookActivator extends BaseModuleActivator {
+    @Override
+    public void started() {
+        var properties = AppointmentWebhookProperties.fromOpenMrsGlobalProperties();
+        var outbox = new FileWebhookOutbox(Path.of(properties.outboxPath()));
+        var dispatcher = new AppointmentWebhookDispatcher(
+            properties,
+            new HmacSigner(),
+            outbox,
+            HttpClient.newHttpClient());
+
+        new EventSubscriptionRegistrar()
+            .registerEncounterListener(new AppointmentEventListener(dispatcher));
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/WebhookOutbox.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/WebhookOutbox.java
@@ -1,0 +1,9 @@
+package org.openmrs.module.openmrswebhook;
+
+import java.util.List;
+
+public interface WebhookOutbox {
+    void enqueue(WebhookOutboxEntry entry);
+    List<WebhookOutboxEntry> readAll();
+    void replaceAll(List<WebhookOutboxEntry> entries);
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/WebhookOutboxEntry.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/WebhookOutboxEntry.java
@@ -1,0 +1,31 @@
+package org.openmrs.module.openmrswebhook;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+public record WebhookOutboxEntry(String eventId, String eventType, String body, Instant queuedAt) {
+    public String encode() {
+        return encode(eventId) + "\t" + encode(eventType) + "\t" + encode(body) + "\t" + queuedAt;
+    }
+
+    public static WebhookOutboxEntry decode(String line) {
+        var parts = line.split("\t", -1);
+        if (parts.length != 4) {
+            throw new IllegalArgumentException("Malformed outbox line.");
+        }
+        return new WebhookOutboxEntry(
+            decodePart(parts[0]),
+            decodePart(parts[1]),
+            decodePart(parts[2]),
+            Instant.parse(parts[3]));
+    }
+
+    private static String encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String decodePart(String value) {
+        return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+    }
+}

--- a/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/WebhookRetryTask.java
+++ b/openmrs-webhook-module/src/main/java/org/openmrs/module/openmrswebhook/WebhookRetryTask.java
@@ -1,0 +1,30 @@
+package org.openmrs.module.openmrswebhook;
+
+import java.util.ArrayList;
+
+public class WebhookRetryTask implements Runnable {
+    private final AppointmentWebhookDispatcher dispatcher;
+    private final WebhookOutbox outbox;
+
+    public WebhookRetryTask(AppointmentWebhookDispatcher dispatcher, WebhookOutbox outbox) {
+        this.dispatcher = dispatcher;
+        this.outbox = outbox;
+    }
+
+    @Override
+    public void run() {
+        runOnce();
+    }
+
+    public void runOnce() {
+        var failed = new ArrayList<WebhookOutboxEntry>();
+        for (WebhookOutboxEntry entry : outbox.readAll()) {
+            try {
+                dispatcher.send(entry.eventId(), entry.eventType(), entry.body());
+            } catch (Exception ex) {
+                failed.add(entry);
+            }
+        }
+        outbox.replaceAll(failed);
+    }
+}

--- a/openmrs-webhook-module/src/test/java/org/openmrs/module/openmrswebhook/HmacSignerTest.java
+++ b/openmrs-webhook-module/src/test/java/org/openmrs/module/openmrswebhook/HmacSignerTest.java
@@ -1,0 +1,14 @@
+package org.openmrs.module.openmrswebhook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class HmacSignerTest {
+    @Test
+    void signsTimestampDotBodyWithSha256() {
+        var signature = new HmacSigner().sign("2026-05-23T10:00:00Z", "{\"encounterId\":\"enc-1\"}", "secret");
+
+        assertEquals("d6755d8bcbca62cb177940b96f00d8aa4ebc83992e91dcb796df6c6064691204", signature);
+    }
+}

--- a/openmrs-webhook-module/src/test/java/org/openmrs/module/openmrswebhook/WebhookOutboxEntryTest.java
+++ b/openmrs-webhook-module/src/test/java/org/openmrs/module/openmrswebhook/WebhookOutboxEntryTest.java
@@ -1,0 +1,17 @@
+package org.openmrs.module.openmrswebhook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class WebhookOutboxEntryTest {
+    @Test
+    void encodeDecodeRoundTrips() {
+        var entry = new WebhookOutboxEntry("evt-1", "CREATED", "{\"encounterId\":\"enc-1\"}", Instant.parse("2026-05-23T10:00:00Z"));
+
+        var decoded = WebhookOutboxEntry.decode(entry.encode());
+
+        assertEquals(entry, decoded);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,10 @@
   <version>3.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <modules>
+    <module>openmrs-webhook-module</module>
+  </modules>
+
   <organization>
     <name>OpenMRS Inc.</name>
     <url>https://openmrs.org</url>


### PR DESCRIPTION
This pull request introduces a new OpenMRS Appointment Webhook Module to the project, providing a mechanism for listening to OpenMRS `Encounter` events and sending signed appointment webhooks to an external backend. The changes include the module's implementation, build configuration, documentation, and integration into the development workflow. There are also updates to the main project to support development and testing.

**OpenMRS Webhook Module Implementation:**

* Added a new Maven module `openmrs-webhook-module` with all necessary source files and a `pom.xml` for build configuration. The module listens for `Encounter` events via the OpenMRS Event Module and dispatches signed webhook requests to a configured backend, with support for HMAC signatures and an outbox for retrying failed deliveries. [[1]](diffhunk://#diff-4df706054ea9fc2272f69b037a9b28a2e988443b94fc5868db4b0a918e33f425R1-R54) [[2]](diffhunk://#diff-e0ea0c32bd1efdc2c19c75081b5cda1d5468e10949b859423aca1c115697148aR1-R71) [[3]](diffhunk://#diff-aa7e60eb760c21c959a42867cdb51410c34ccc82a094cb1489c5166dcc64390cR1-R59) [[4]](diffhunk://#diff-b7d2fc2c51bdf4fe84e8c072c47c086a44fa209ccd29c9b709ed442e9e492a00R1-R35) [[5]](diffhunk://#diff-988bea124a7abb439d2f52264d30bdf1bf72662d7593a1687c18e5025fc39167R1-R20) [[6]](diffhunk://#diff-635110f11a07189f21072e2fd7783eb01ec114bb21f3a1a8d5314a14ab6e787eR1-R21) [[7]](diffhunk://#diff-fec8b1e5ca5c89335905a68518b628d1af7010eeb95ae7c94be17aca5f4ef8d5R1-R65) [[8]](diffhunk://#diff-bb992da1afe851baed29c589149b0d7e26188099408c0b61852e95f2ac1c159eR1-R26) [[9]](diffhunk://#diff-a53c0e547fdb1d2207900d441a33a351d0b7ed04596f285702cc07f39cd69e71R1-R21) [[10]](diffhunk://#diff-1eb2be440ab98bd236db98aeaa3a3a96d41c52d64f9ac548319c765f93111d4dR1-R9) [[11]](diffhunk://#diff-1cb4ec3d3c51a2dcaf3bfd2fbba3e0313fe05e55065b7ce9290c8f6cc1690831R1-R31) [[12]](diffhunk://#diff-5ed33ec014cf4f390d6b15746228affd1d405d97326ce95ab9375b8e57d9d4f8R1-R30)

**Documentation and Configuration:**

* Added module-specific documentation in `openmrs-webhook-module/README.md` and updated the main `README.md` to describe the webhook module, its configuration properties, and usage instructions. [[1]](diffhunk://#diff-07eb7ac26ad4ee0a4fd11ac456a91d399973bd9fe69c3c7d7138ecca615ac3ccR1-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R68)
* Added a `.gitleaks.toml` allowlist to permit demo credentials and documentation examples, avoiding false positives in secret scanning.

**Development and CI Workflow:**

* Introduced a new GitHub Actions workflow (`.github/workflows/openmrs-webhook-module-ci.yml`) to build, test, and scan the webhook module for secrets on pushes and pull requests.

**Docker Compose and Runtime Improvements:**

* Changed the `gateway` service port mapping in `docker-compose.yml` from `80:80` to `3032:80` to avoid conflicts and allow parallel development.
* Exposed the OpenMRS backend debug port (`5005`) and enabled it via environment variable for easier debugging during development.