### PR TITLE
fix(O3-4977): Unwanted referenceapplication-demo folder in RefApp 3.4.0 build

### DIFF
--- a/distro/distro.properties
+++ b/distro/distro.properties
@@ -37,3 +37,4 @@ omod.billing=${billing.version}
 omod.tasks=${tasks.version}
 content.referenceapplication=${reference-content.version}
 content.referenceapplication-demo=${reference-demo-content.version}
+content.referenceapplication-demo.namespace=referenceapplication


### PR DESCRIPTION
Added `content.referenceapplication-demo.namespace=referenceapplication` to `distro.properties`. This tells the SDK to use `referenceapplication` as the namespace, merging the demo content into the correct domain folder.

Before :
<img width="315" height="267" alt="Screenshot 2025-08-06 at 6 42 07 PM (1)" src="https://github.com/user-attachments/assets/906f28d8-6d2c-4a81-8e96-d4389797c18e" />

After :
<img width="526" height="404" alt="hh" src="https://github.com/user-attachments/assets/d07b694e-701c-4e1f-94e2-1114c58080a5" />


Verification :
1. Run `mvn clean package` in the `distro/` directory
2. Run `jar tf target/distro-emr-configuration-3.7.0-SNAPSHOT.zip | findstr "referenceapplication-demo"`
3. No output confirms , the unwanted folder is therefore removed .

Ticket : https://openmrs.atlassian.net/browse/O3-4977