### PR TITLE
(fix) O3-5732: Use esm-patient-task-list-app for patient chart task list

### DIFF
--- a/frontend/spa-assemble-config.json
+++ b/frontend/spa-assemble-config.json
@@ -34,6 +34,7 @@
     "@openmrs/esm-patient-programs-app": "latest",
     "@openmrs/esm-patient-registration-app": "latest",
     "@openmrs/esm-patient-search-app": "latest",
+    "@openmrs/esm-patient-task-list-app": "latest",
     "@openmrs/esm-patient-tests-app": "latest",
     "@openmrs/esm-patient-vitals-app": "latest",
     "@openmrs/esm-patient-procedures-app": "latest",
@@ -42,7 +43,6 @@
     "@openmrs/esm-service-queues-app": "latest",
     "@openmrs/esm-stock-management-app": "latest",
     "@openmrs/esm-system-admin-app": "latest",
-    "@openmrs/esm-task-list-app": "latest",
     "@openmrs/esm-user-onboarding-app": "latest",
     "@openmrs/esm-ward-app": "latest"
   },


### PR DESCRIPTION
## Summary

Replaces the standalone `@openmrs/esm-task-list-app` with `@openmrs/esm-patient-task-list-app` in the SPA assemble config.

The task list functionality was ported into the patient chart as a workspace (`@openmrs/esm-patient-task-list-app`), which registers a `workspaceWindows2` entry in the `patient-chart` group. The standalone `@openmrs/esm-task-list-app` does not register that workspace window, so the task list does not appear in the patient chart workspace on builds using this distro (e.g. test3).

## Screenshots

N/A — config change.

## Related Issue

The patient-chart task list workspace is provided by `@openmrs/esm-patient-task-list-app` (shipped in openmrs-esm-patient-chart 12.2.0). This distro previously only included the legacy standalone app.
