### PR TITLE
(feat) Show patient ID column in lab table

### DIFF
--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -15,6 +15,9 @@
       }
     }
   },
+  "@openmrs/esm-laboratory-app": {
+    "labTableColumns": ["name", "patientId", "urgency", "age", "sex", "totalOrders", "action"]
+  },
   "@openmrs/esm-styleguide": {
     "Brand color #1": "#005d5d"
   }


### PR DESCRIPTION
Adds laboratory app table configuration to the RefApp frontend config so the lab orders table includes the Patient ID column.

This keeps the laboratory app's default identifier settings, so RefApp uses the app's default OpenMRS ID identifier type and preferred-identifier behavior.

Follow-up to https://github.com/openmrs/openmrs-esm-laboratory-app/pull/779.
