### PR TITLE
Switch from snapshot to released version of teleconsultation module

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -37,7 +37,7 @@
     <referencedemodata.version>2.6.1</referencedemodata.version>
     <queue.version>3.0.0</queue.version>
     <appointments.version>2.1.0</appointments.version>
-    <teleconsultation.version>2.1.0-20250318.154145-1</teleconsultation.version>
+    <teleconsultation.version>2.0.0</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>
     <authentication.version>2.3.0</authentication.version>
     <reporting.version>2.1.0</reporting.version>


### PR DESCRIPTION
## What

Switch `teleconsultation.version` from the timestamped snapshot `2.1.0-20250318.154145-1` to the released `2.0.0`.

## Why

`2.1.0` was never released — the only releases of `org.bahmni.module:teleconsultation-omod` are `1.0.0`, `1.1.0`, `1.2.0`, and `2.0.0` (the repo's `<release>` marker is `2.0.0`, and the only tags upstream are `2.0.0` and `1.2.0-AGPLv3`). The current pin is a non-reproducible timestamped SNAPSHOT.

The snapshot is only **2 commits** past the `2.0.0` tag, and both are pure infrastructure — a dev-version bump and a migration of the publishing mechanism from OSSRH to the Sonatype Central Portal. There are **no Java, `config.xml`, REST, or dependency changes**, so this is functionally identical while replacing a snapshot that can be garbage-collected with a stable, immutable release.

This mirrors the earlier switch done for the appointments module.

## Compatibility (verified against the module source/`config.xml`)

- `require_version` = `2.4.2` → distro core is `2.8.7` ✓
- `require_modules` = only `webservices.rest` → distro has `3.5.0` ✓ (no dependency on the appointments module)
- Same artifact form (published as `.jar`, like the other Bahmni modules), so SDK resolution/installation is unchanged.

## Test plan

- [ ] Distro build (`mvn ... -Pdistro`) resolves `teleconsultation-omod:2.0.0` and packages the distro.
- [ ] Teleconsultation module loads and starts in a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
