### PR TITLE
(feat) Add test3 QA deployment workflow (Publish QA Release deploy half)

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -48,10 +48,13 @@ test3/o3.openmrs.org) are **not** ported — see below.
    **Release: Deploy QA to test3** workflow (`deploy-test3.yml`) refreshes
    the server — automatically once all three RC image builds have
    published, or by manual dispatch. It requires infrastructure to
-   provision `TEST3_DEPLOY_SSH_KEY` and `TEST3_SERVER_HOST` secrets
-   (test3-specific names — deliberately not dev3's `DEPLOY_SSH_KEY` /
-   `SERVER_HOST`, which this repo already inherits and which point at the
-   wrong server); until then it no-ops and the fallback is the Bamboo
+   provision `TEST3_DEPLOY_SSH_KEY` and `TEST3_SERVER_HOST` as
+   **repository- or organization-level** secrets (environment-scoped
+   secrets are invisible to the gate job; and the names are deliberately
+   not dev3's `DEPLOY_SSH_KEY` / `SERVER_HOST`, which this repo already
+   inherits and which point at the wrong server). Until then automatic
+   runs no-op with a warning and manual dispatches fail with
+   instructions; the fallback is the Bamboo
    [Publish QA Release](https://ci.openmrs.org/browse/O3-PQR) deploy step
    or `#infrastructure`. Then work through the
    [QA checklist](https://om.rs/o3qasheet).
@@ -71,8 +74,10 @@ review and merge it like any other PR.
 ## Not (yet) ported
 
 - **Server container refreshes**: test3.openmrs.org has a workflow
-  (`deploy-test3.yml`) that no-ops until infrastructure provisions the
-  `TEST3_DEPLOY_SSH_KEY` / `TEST3_SERVER_HOST` secrets. o3.openmrs.org
+  (`deploy-test3.yml`) whose automatic runs no-op (and manual runs fail
+  with instructions) until infrastructure provisions the
+  `TEST3_DEPLOY_SSH_KEY` / `TEST3_SERVER_HOST` repo- or org-level
+  secrets. o3.openmrs.org
   (`demo` images) has **no workflow yet** — its refresh remains entirely
   with infrastructure, via the
   [Deploy Reference Application 3.x](https://ci.openmrs.org/deploy/viewDeploymentProjectEnvironments.action?id=222593025)

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -46,10 +46,12 @@ test3/o3.openmrs.org) are **not** ported — see below.
    rejects re-deployment, cut the next RC instead.
 4. **QA on test3.openmrs.org** once it runs the new `qa` images. The
    **Release: Deploy QA to test3** workflow (`deploy-test3.yml`) refreshes
-   the server — automatically after the RC backend image build completes,
-   or by manual dispatch. It requires infrastructure to provision the
-   `test3` GitHub environment (`DEPLOY_SSH_KEY` / `SERVER_HOST`, like
-   dev3's); until then it no-ops and the fallback is the Bamboo
+   the server — automatically once all three RC image builds have
+   published, or by manual dispatch. It requires infrastructure to
+   provision `TEST3_DEPLOY_SSH_KEY` and `TEST3_SERVER_HOST` secrets
+   (test3-specific names — deliberately not dev3's `DEPLOY_SSH_KEY` /
+   `SERVER_HOST`, which this repo already inherits and which point at the
+   wrong server); until then it no-ops and the fallback is the Bamboo
    [Publish QA Release](https://ci.openmrs.org/browse/O3-PQR) deploy step
    or `#infrastructure`. Then work through the
    [QA checklist](https://om.rs/o3qasheet).
@@ -69,12 +71,12 @@ review and merge it like any other PR.
 ## Not (yet) ported
 
 - **Server container refreshes**: test3.openmrs.org has a workflow
-  (`deploy-test3.yml`) that is a no-op until infrastructure provisions the
-  `test3` environment secrets; o3.openmrs.org (`demo` images) is still
-  refreshed by infrastructure — via the
+  (`deploy-test3.yml`) that no-ops until infrastructure provisions the
+  `TEST3_DEPLOY_SSH_KEY` / `TEST3_SERVER_HOST` secrets. o3.openmrs.org
+  (`demo` images) has **no workflow yet** — its refresh remains entirely
+  with infrastructure, via the
   [Deploy Reference Application 3.x](https://ci.openmrs.org/deploy/viewDeploymentProjectEnvironments.action?id=222593025)
-  deployment project or `#infrastructure`. Both follow the
-  `deploy-dev3.yml` scoped-SSH pattern once keys exist.
+  deployment project or `#infrastructure`.
 - Bamboo remains available as a fallback; these workflows use the same
   branch/tag/commit conventions it did.
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -45,9 +45,13 @@ test3/o3.openmrs.org) are **not** ported — see below.
    the same release version to the Maven repository; if the repository
    rejects re-deployment, cut the next RC instead.
 4. **QA on test3.openmrs.org** once it runs the new `qa` images. The
-   container refresh is not yet ported: trigger it via the Bamboo
-   [Publish QA Release](https://ci.openmrs.org/browse/O3-PQR) deploy step,
-   or ask in `#infrastructure` on the OpenMRS Slack. Then work through the
+   **Release: Deploy QA to test3** workflow (`deploy-test3.yml`) refreshes
+   the server — automatically after the RC backend image build completes,
+   or by manual dispatch. It requires infrastructure to provision the
+   `test3` GitHub environment (`DEPLOY_SSH_KEY` / `SERVER_HOST`, like
+   dev3's); until then it no-ops and the fallback is the Bamboo
+   [Publish QA Release](https://ci.openmrs.org/browse/O3-PQR) deploy step
+   or `#infrastructure`. Then work through the
    [QA checklist](https://om.rs/o3qasheet).
 5. **Run "Release: Promote to Production"** with the `release_version`.
    It pins the frontend to the *exact* module versions QA tested (from the
@@ -64,14 +68,13 @@ review and merge it like any other PR.
 
 ## Not (yet) ported
 
-- **Server container refreshes**: test3.openmrs.org (`qa` images) and
-  o3.openmrs.org (`demo` images) are still refreshed by the OpenMRS
-  infrastructure — via the [Publish QA Release](https://ci.openmrs.org/browse/O3-PQR)
-  deploy step and the
+- **Server container refreshes**: test3.openmrs.org has a workflow
+  (`deploy-test3.yml`) that is a no-op until infrastructure provisions the
+  `test3` environment secrets; o3.openmrs.org (`demo` images) is still
+  refreshed by infrastructure — via the
   [Deploy Reference Application 3.x](https://ci.openmrs.org/deploy/viewDeploymentProjectEnvironments.action?id=222593025)
-  deployment project, or by asking in `#infrastructure`. The
-  `deploy-dev3.yml` scoped-SSH pattern can be extended to them once
-  infrastructure provisions deploy keys.
+  deployment project or `#infrastructure`. Both follow the
+  `deploy-dev3.yml` scoped-SSH pattern once keys exist.
 - Bamboo remains available as a fallback; these workflows use the same
   branch/tag/commit conventions it did.
 

--- a/.github/workflows/deploy-test3.yml
+++ b/.github/workflows/deploy-test3.yml
@@ -39,7 +39,9 @@ permissions: {}
 # trigger. Per-ref groups make that impossible; the deploy job below has its
 # own group to serialize the actual SSH deploys.
 concurrency:
-  group: deploy-test3-${{ github.event.workflow_run.head_branch || 'manual' }}
+  # ':' cannot appear in a git ref, so the manual-dispatch group can never
+  # collide with a group derived from a branch or tag name.
+  group: deploy-test3-${{ github.event.workflow_run.head_branch || ':manual' }}
   cancel-in-progress: false
 
 jobs:
@@ -90,10 +92,12 @@ jobs:
             for repo in backend frontend gateway; do
               code=""
               for attempt in 1 2 3; do
-                code=$(curl -s -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags/$RC_TAG" || true)
+                code=$(curl -s --max-time 20 -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags/$RC_TAG" || true)
                 if [ "$code" = "200" ] || [ "$code" = "404" ]; then break; fi
-                echo "$repo:$RC_TAG — attempt $attempt got HTTP ${code:-000}; retrying"
-                if [ "$attempt" -lt 3 ]; then sleep $(( attempt * 15 )); fi
+                if [ "$attempt" -lt 3 ]; then
+                  echo "$repo:$RC_TAG — attempt $attempt got HTTP ${code:-000}; retrying"
+                  sleep $(( attempt * 15 ))
+                fi
               done
               if [ "$code" = "404" ]; then
                 echo "::notice::$repo:$RC_TAG is not on Docker Hub yet — deferring; the deploy fires when the remaining builds finish (or dispatch this workflow manually)."
@@ -124,7 +128,8 @@ jobs:
     # GitHub keeps the newest pending one — which is correct here, since the
     # newest deploy pulls the newest images.
     concurrency:
-      group: deploy-test3-ssh
+      # '::' keeps this group outside the ref-derived namespace above.
+      group: deploy-test3::ssh
       cancel-in-progress: false
     environment:
       name: test3

--- a/.github/workflows/deploy-test3.yml
+++ b/.github/workflows/deploy-test3.yml
@@ -30,8 +30,16 @@ on:
     workflows: ["Build Backend", "Build Frontend", "Build Gateway"]
     types: [completed]
 
+# No GITHUB_TOKEN use in either job.
+permissions: {}
+
+# Group per triggering ref: GitHub keeps only one PENDING run per group and
+# cancels the older pending one, so a shared group would let a main-branch
+# build completion silently cancel the pending run of the deciding RC
+# trigger. Per-ref groups make that impossible; the deploy job below has its
+# own group to serialize the actual SSH deploys.
 concurrency:
-  group: deploy-test3
+  group: deploy-test3-${{ github.event.workflow_run.head_branch || 'manual' }}
   cancel-in-progress: false
 
 jobs:
@@ -60,7 +68,7 @@ jobs:
           set -euo pipefail
           go=true
           if [ "$PROVISIONED" != "true" ]; then
-            MSG="test3 deploy credentials are not provisioned (TEST3_DEPLOY_SSH_KEY / TEST3_SERVER_HOST secrets — note: NOT the dev3 DEPLOY_SSH_KEY/SERVER_HOST names). Refresh test3 via the Bamboo Publish QA Release deploy step (https://ci.openmrs.org/browse/O3-PQR) or #infrastructure instead."
+            MSG="test3 deploy credentials are not provisioned: TEST3_DEPLOY_SSH_KEY / TEST3_SERVER_HOST must be REPO- or ORG-level secrets (environment-scoped secrets are invisible to this gate, and the dev3 DEPLOY_SSH_KEY/SERVER_HOST names must not be reused). Refresh test3 via the Bamboo Publish QA Release deploy step (https://ci.openmrs.org/browse/O3-PQR) or #infrastructure instead."
             {
               echo "## :warning: test3 was NOT deployed"
               echo "$MSG"
@@ -75,16 +83,29 @@ jobs:
           elif [ "$EVENT" = "workflow_run" ]; then
             # Each build's completion triggers this workflow; deploy only once
             # ALL three RC images are published, i.e. on the last trigger.
+            # A 404 is a genuine not-yet-published (defer, green); transport
+            # errors or rate limits must NOT defer — on the final build's
+            # trigger no later trigger is coming, so an indeterminate check
+            # fails red to put a human in the loop.
             for repo in backend frontend gateway; do
-              code=$(curl -s -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags/$RC_TAG" || true)
-              if [ "$code" != "200" ]; then
-                echo "::notice::$repo:$RC_TAG is not on Docker Hub yet (HTTP $code) — deferring; the deploy fires when the remaining builds finish (or dispatch this workflow manually)."
+              code=""
+              for attempt in 1 2 3; do
+                code=$(curl -s -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags/$RC_TAG" || true)
+                if [ "$code" = "200" ] || [ "$code" = "404" ]; then break; fi
+                echo "$repo:$RC_TAG — attempt $attempt got HTTP ${code:-000}; retrying"
+                if [ "$attempt" -lt 3 ]; then sleep $(( attempt * 15 )); fi
+              done
+              if [ "$code" = "404" ]; then
+                echo "::notice::$repo:$RC_TAG is not on Docker Hub yet — deferring; the deploy fires when the remaining builds finish (or dispatch this workflow manually)."
                 {
                   echo "## :hourglass: test3 deploy deferred"
                   echo "\`$repo:$RC_TAG\` is not published yet — a later build's trigger (or a manual dispatch) completes the deploy."
                 } >> "$GITHUB_STEP_SUMMARY"
                 go=false
                 break
+              elif [ "$code" != "200" ]; then
+                echo "::error::Docker Hub check for $repo:$RC_TAG failed (HTTP ${code:-000}) — cannot tell whether the RC images are complete. Re-run this workflow or dispatch it manually once Docker Hub recovers."
+                exit 1
               fi
             done
           fi
@@ -99,6 +120,12 @@ jobs:
     if: needs.gate.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Serialize actual SSH deploys across all triggering refs; if two queue,
+    # GitHub keeps the newest pending one — which is correct here, since the
+    # newest deploy pulls the newest images.
+    concurrency:
+      group: deploy-test3-ssh
+      cancel-in-progress: false
     environment:
       name: test3
       url: https://test3.openmrs.org/openmrs/spa
@@ -116,7 +143,7 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -t ed25519 "$SERVER_HOST" >> ~/.ssh/known_hosts
+          ssh-keyscan -t ed25519,ecdsa,rsa "$SERVER_HOST" >> ~/.ssh/known_hosts
 
           ssh -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=yes \

--- a/.github/workflows/deploy-test3.yml
+++ b/.github/workflows/deploy-test3.yml
@@ -1,0 +1,77 @@
+name: 'Release: Deploy QA to test3'
+
+# Replaces the server-deployment half of the Bamboo "Publish QA Release"
+# (O3-PQR) job: refreshes test3.openmrs.org so it runs the latest :qa images
+# published by a "Release: Cut QA (RC)" run.
+#
+# Triggers automatically when a release-candidate Build Backend run completes
+# (the longest of the three image builds a QA release dispatches — the
+# frontend and gateway images are published well before it), and can also be
+# dispatched manually.
+#
+# Uses the same scoped-SSH pattern as deploy-dev3.yml. Until the `test3`
+# GitHub environment is provisioned with DEPLOY_SSH_KEY / SERVER_HOST, runs
+# as a no-op with a notice instead of failing, so it is safe to merge ahead
+# of infrastructure. The remote deploy target defaults to `emr-3-test`
+# (following the emr-3-dev naming); set the TEST3_DEPLOY_TARGET variable on
+# the environment if infrastructure uses a different name.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reset:
+        description: 'Fully resets the test3 instance (destroys volumes)'
+        type: boolean
+        default: false
+  workflow_run:
+    workflows: ["Build Backend"]
+    types: [completed]
+
+concurrency:
+  group: deploy-test3
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy QA images to test3
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Automatic path: only after a successful image build on an RC tag
+    # (tag refs like 3.7.1-rc.2 — never plain branches or final versions,
+    # whose images belong to demo/o3, not test3).
+    if: >-
+      github.repository_owner == 'openmrs' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        contains(github.event.workflow_run.head_branch, '-rc.')))
+    environment:
+      name: test3
+      url: https://test3.openmrs.org/openmrs/spa
+    steps:
+      - name: Check deploy credentials are provisioned
+        id: gate
+        env:
+          PROVISIONED: ${{ secrets.DEPLOY_SSH_KEY != '' && secrets.SERVER_HOST != '' }}
+        run: |
+          set -euo pipefail
+          echo "provisioned=$PROVISIONED" >> "$GITHUB_OUTPUT"
+          if [ "$PROVISIONED" != "true" ]; then
+            echo "::notice::test3 deploy credentials are not provisioned (DEPLOY_SSH_KEY / SERVER_HOST on the 'test3' environment) — skipping. Refresh test3 via the Bamboo Publish QA Release deploy step (https://ci.openmrs.org/browse/O3-PQR) or #infrastructure instead."
+          fi
+
+      - name: Deploy via scoped SSH
+        if: steps.gate.outputs.provisioned == 'true'
+        env:
+          DEPLOY_TARGET: ${{ vars.TEST3_DEPLOY_TARGET || 'emr-3-test' }}
+          RESET_FLAGS: ${{ inputs.reset && ' --destroy-volumes' || '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -t ed25519 ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=yes \
+            deploy@${{ secrets.SERVER_HOST }} \
+            "deploy ${DEPLOY_TARGET}${RESET_FLAGS} --no-health-check"

--- a/.github/workflows/deploy-test3.yml
+++ b/.github/workflows/deploy-test3.yml
@@ -4,17 +4,20 @@ name: 'Release: Deploy QA to test3'
 # (O3-PQR) job: refreshes test3.openmrs.org so it runs the latest :qa images
 # published by a "Release: Cut QA (RC)" run.
 #
-# Triggers automatically when a release-candidate Build Backend run completes
-# (the longest of the three image builds a QA release dispatches — the
-# frontend and gateway images are published well before it), and can also be
-# dispatched manually.
+# Triggers when any of the three image builds completes on a release-candidate
+# tag; the gate only proceeds once ALL three :rc images are on Docker Hub, so
+# the deploy effectively fires on the last build to finish (and a re-dispatched
+# recovery build re-arms it). Manual dispatch skips the completeness check.
 #
-# Uses the same scoped-SSH pattern as deploy-dev3.yml. Until the `test3`
-# GitHub environment is provisioned with DEPLOY_SSH_KEY / SERVER_HOST, runs
-# as a no-op with a notice instead of failing, so it is safe to merge ahead
-# of infrastructure. The remote deploy target defaults to `emr-3-test`
-# (following the emr-3-dev naming); set the TEST3_DEPLOY_TARGET variable on
-# the environment if infrastructure uses a different name.
+# Uses the same scoped-SSH approach as deploy-dev3.yml but with test3-SPECIFIC
+# secret names (TEST3_DEPLOY_SSH_KEY / TEST3_SERVER_HOST, repo or org level):
+# the generic DEPLOY_SSH_KEY / SERVER_HOST names are already provisioned for
+# dev3 and would be inherited here, silently pointing this workflow at the
+# wrong server. Until the TEST3_* secrets exist, automatic runs no-op with a
+# warning (manual runs fail loudly) and no GitHub deployment record is created
+# — the gate job is deliberately not environment-bound. The remote deploy
+# target defaults to `emr-3-test` (following the emr-3-dev naming); set the
+# TEST3_DEPLOY_TARGET repository variable if infrastructure uses another name.
 
 on:
   workflow_dispatch:
@@ -24,7 +27,7 @@ on:
         type: boolean
         default: false
   workflow_run:
-    workflows: ["Build Backend"]
+    workflows: ["Build Backend", "Build Frontend", "Build Gateway"]
     types: [completed]
 
 concurrency:
@@ -32,47 +35,78 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy QA images to test3
+  gate:
+    name: Check credentials and image completeness
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    # Automatic path: only after a successful image build on an RC tag
-    # (tag refs like 3.7.1-rc.2 — never plain branches or final versions,
-    # whose images belong to demo/o3, not test3).
+    timeout-minutes: 5
+    # Automatic path: only successful image builds on RC tag refs (like
+    # 3.7.1-rc.2 — never plain branches, and never final-version tags,
+    # whose images belong to demo/o3 rather than test3).
     if: >-
       github.repository_owner == 'openmrs' &&
       (github.event_name == 'workflow_dispatch' ||
        (github.event.workflow_run.conclusion == 'success' &&
         contains(github.event.workflow_run.head_branch, '-rc.')))
-    environment:
-      name: test3
-      url: https://test3.openmrs.org/openmrs/spa
+    outputs:
+      go: ${{ steps.decide.outputs.go }}
     steps:
-      - name: Check deploy credentials are provisioned
-        id: gate
+      - name: Decide whether to deploy
+        id: decide
         env:
-          PROVISIONED: ${{ secrets.DEPLOY_SSH_KEY != '' && secrets.SERVER_HOST != '' }}
+          PROVISIONED: ${{ secrets.TEST3_DEPLOY_SSH_KEY != '' && secrets.TEST3_SERVER_HOST != '' }}
           EVENT: ${{ github.event_name }}
+          RC_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-          echo "provisioned=$PROVISIONED" >> "$GITHUB_OUTPUT"
+          go=true
           if [ "$PROVISIONED" != "true" ]; then
-            MSG="test3 deploy credentials are not provisioned (DEPLOY_SSH_KEY / SERVER_HOST on the 'test3' environment). Refresh test3 via the Bamboo Publish QA Release deploy step (https://ci.openmrs.org/browse/O3-PQR) or #infrastructure instead."
-            echo "## :warning: test3 was NOT deployed" >> "$GITHUB_STEP_SUMMARY"
-            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+            MSG="test3 deploy credentials are not provisioned (TEST3_DEPLOY_SSH_KEY / TEST3_SERVER_HOST secrets — note: NOT the dev3 DEPLOY_SSH_KEY/SERVER_HOST names). Refresh test3 via the Bamboo Publish QA Release deploy step (https://ci.openmrs.org/browse/O3-PQR) or #infrastructure instead."
+            {
+              echo "## :warning: test3 was NOT deployed"
+              echo "$MSG"
+            } >> "$GITHUB_STEP_SUMMARY"
             if [ "$EVENT" = "workflow_dispatch" ]; then
               # An operator explicitly asked for a deploy: a green no-op here
               # would read as "deployed". Fail honestly.
               echo "::error::$MSG"; exit 1
             fi
             echo "::notice::$MSG"
+            go=false
+          elif [ "$EVENT" = "workflow_run" ]; then
+            # Each build's completion triggers this workflow; deploy only once
+            # ALL three RC images are published, i.e. on the last trigger.
+            for repo in backend frontend gateway; do
+              code=$(curl -s -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags/$RC_TAG" || true)
+              if [ "$code" != "200" ]; then
+                echo "::notice::$repo:$RC_TAG is not on Docker Hub yet (HTTP $code) — deferring; the deploy fires when the remaining builds finish (or dispatch this workflow manually)."
+                {
+                  echo "## :hourglass: test3 deploy deferred"
+                  echo "\`$repo:$RC_TAG\` is not published yet — a later build's trigger (or a manual dispatch) completes the deploy."
+                } >> "$GITHUB_STEP_SUMMARY"
+                go=false
+                break
+              fi
+            done
           fi
+          echo "go=$go" >> "$GITHUB_OUTPUT"
 
+  deploy:
+    name: Deploy QA images to test3
+    needs: gate
+    # Skipped (not run) when the gate says no — a skipped job creates no
+    # GitHub deployment record, so the Deployments view never shows a
+    # phantom "deployed to test3".
+    if: needs.gate.outputs.go == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: test3
+      url: https://test3.openmrs.org/openmrs/spa
+    steps:
       - name: Deploy via scoped SSH
-        if: steps.gate.outputs.provisioned == 'true'
         env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          DEPLOY_KEY: ${{ secrets.TEST3_DEPLOY_SSH_KEY }}
+          SERVER_HOST: ${{ secrets.TEST3_SERVER_HOST }}
           DEPLOY_TARGET: ${{ vars.TEST3_DEPLOY_TARGET || 'emr-3-test' }}
           RESET_FLAGS: ${{ inputs.reset && ' --destroy-volumes' || '' }}
         run: |

--- a/.github/workflows/deploy-test3.yml
+++ b/.github/workflows/deploy-test3.yml
@@ -52,26 +52,39 @@ jobs:
         id: gate
         env:
           PROVISIONED: ${{ secrets.DEPLOY_SSH_KEY != '' && secrets.SERVER_HOST != '' }}
+          EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
           echo "provisioned=$PROVISIONED" >> "$GITHUB_OUTPUT"
           if [ "$PROVISIONED" != "true" ]; then
-            echo "::notice::test3 deploy credentials are not provisioned (DEPLOY_SSH_KEY / SERVER_HOST on the 'test3' environment) — skipping. Refresh test3 via the Bamboo Publish QA Release deploy step (https://ci.openmrs.org/browse/O3-PQR) or #infrastructure instead."
+            MSG="test3 deploy credentials are not provisioned (DEPLOY_SSH_KEY / SERVER_HOST on the 'test3' environment). Refresh test3 via the Bamboo Publish QA Release deploy step (https://ci.openmrs.org/browse/O3-PQR) or #infrastructure instead."
+            echo "## :warning: test3 was NOT deployed" >> "$GITHUB_STEP_SUMMARY"
+            echo "$MSG" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$EVENT" = "workflow_dispatch" ]; then
+              # An operator explicitly asked for a deploy: a green no-op here
+              # would read as "deployed". Fail honestly.
+              echo "::error::$MSG"; exit 1
+            fi
+            echo "::notice::$MSG"
           fi
 
       - name: Deploy via scoped SSH
         if: steps.gate.outputs.provisioned == 'true'
         env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
           DEPLOY_TARGET: ${{ vars.TEST3_DEPLOY_TARGET || 'emr-3-test' }}
           RESET_FLAGS: ${{ inputs.reset && ' --destroy-volumes' || '' }}
         run: |
           set -euo pipefail
+          [[ "$DEPLOY_TARGET" =~ ^[A-Za-z0-9][A-Za-z0-9-]*$ ]] \
+            || { echo "::error::TEST3_DEPLOY_TARGET must be a plain target name (got: $DEPLOY_TARGET)"; exit 1; }
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -t ed25519 ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -t ed25519 "$SERVER_HOST" >> ~/.ssh/known_hosts
 
           ssh -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=yes \
-            deploy@${{ secrets.SERVER_HOST }} \
+            "deploy@$SERVER_HOST" \
             "deploy ${DEPLOY_TARGET}${RESET_FLAGS} --no-health-check"

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -313,7 +313,7 @@ jobs:
             echo "- Image builds: [watch here](https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3A$RC_TAG) — they publish \`openmrs/openmrs-reference-application-3-{backend,frontend,gateway}:$RC_TAG\` and \`:qa\`"
             echo ""
             echo "### Next steps"
-            echo "1. Refresh test3.openmrs.org so it picks up the new \`qa\` images — the *Release: Deploy QA to test3* workflow fires automatically once all three RC image builds have published (or dispatch it manually; it no-ops with instructions until the TEST3_* deploy secrets are provisioned)."
+            echo "1. Refresh test3.openmrs.org so it picks up the new \`qa\` images — the *Release: Deploy QA to test3* workflow fires automatically once all three RC image builds have published (or dispatch it manually). Until the TEST3_* deploy secrets are provisioned, automatic runs no-op and manual dispatches fail with instructions."
             echo "2. Run through the [QA checklist](https://om.rs/o3qasheet) on test3."
             echo "3. Fixes needed? Commit them to \`releases/$V\` and re-run this workflow for the next RC."
             echo "4. QA passed? Run the *Release: Promote to Production* workflow."

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -313,7 +313,7 @@ jobs:
             echo "- Image builds: [watch here](https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3A$RC_TAG) — they publish \`openmrs/openmrs-reference-application-3-{backend,frontend,gateway}:$RC_TAG\` and \`:qa\`"
             echo ""
             echo "### Next steps"
-            echo "1. Refresh test3.openmrs.org so it picks up the new \`qa\` images — the *Release: Deploy QA to test3* workflow fires automatically after the backend image build (or dispatch it manually; falls back to a no-op with instructions until infrastructure provisions the test3 environment)."
+            echo "1. Refresh test3.openmrs.org so it picks up the new \`qa\` images — the *Release: Deploy QA to test3* workflow fires automatically once all three RC image builds have published (or dispatch it manually; it no-ops with instructions until the TEST3_* deploy secrets are provisioned)."
             echo "2. Run through the [QA checklist](https://om.rs/o3qasheet) on test3."
             echo "3. Fixes needed? Commit them to \`releases/$V\` and re-run this workflow for the next RC."
             echo "4. QA passed? Run the *Release: Promote to Production* workflow."

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -313,7 +313,7 @@ jobs:
             echo "- Image builds: [watch here](https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3A$RC_TAG) — they publish \`openmrs/openmrs-reference-application-3-{backend,frontend,gateway}:$RC_TAG\` and \`:qa\`"
             echo ""
             echo "### Next steps"
-            echo "1. Refresh test3.openmrs.org so it picks up the new \`qa\` images (Bamboo *Publish QA Release* deploy step / infrastructure — not yet ported)."
+            echo "1. Refresh test3.openmrs.org so it picks up the new \`qa\` images — the *Release: Deploy QA to test3* workflow fires automatically after the backend image build (or dispatch it manually; falls back to a no-op with instructions until infrastructure provisions the test3 environment)."
             echo "2. Run through the [QA checklist](https://om.rs/o3qasheet) on test3."
             echo "3. Fixes needed? Commit them to \`releases/$V\` and re-run this workflow for the next RC."
             echo "4. QA passed? Run the *Release: Promote to Production* workflow."


### PR DESCRIPTION
## What

Adds **Release: Deploy QA to test3** (`deploy-test3.yml`) — the server-deployment half of Bamboo's *Publish QA Release* (O3-PQR), the last Bamboo-only step in the QA phase of the release process ported in #1045.

- **Triggers**: fires when any of the three image builds (backend/frontend/gateway) completes on a release-candidate tag, and **deploys only once all three `:rc` images are on Docker Hub** — i.e. effectively on the last build to finish. A re-dispatched recovery build re-arms it. Final-version builds (demo/o3) are excluded. Manual dispatch (with an optional full-reset input) skips the completeness check.
- **Mechanism**: `deploy-dev3.yml`'s scoped-SSH pattern, but with **test3-specific secret names — `TEST3_DEPLOY_SSH_KEY` and `TEST3_SERVER_HOST`**, which must be **repo- or org-level** (environment-scoped secrets are invisible to the unbound gate job). ⚠️ This is deliberate and load-bearing: the generic `DEPLOY_SSH_KEY` (org secret) / `SERVER_HOST` (repo secret) are already provisioned for dev3 and inherited by every job in this repo — reusing those names would have pointed this workflow at **dev3's server** from day one. The remote target defaults to `emr-3-test` (`TEST3_DEPLOY_TARGET` repo variable overrides it).
- **Safe to merge before provisioning**: automatic runs no-op with a run-summary warning and a `::notice::` pointing at the Bamboo/`#infrastructure` fallback; **manual** dispatches fail loudly (an operator who asked for a deploy must not see a green no-op). The gate job is not environment-bound and the deploy job is skipped outright when gated off, so **no phantom GitHub deployment records** are ever created for no-op runs.

Also updates `.github/RELEASING.md` (including correcting an implication that an o3 deploy workflow exists — it doesn't; o3 remains with infrastructure) and the release-qa run-summary text.

## For infrastructure

To activate: add `TEST3_DEPLOY_SSH_KEY` + `TEST3_SERVER_HOST` as **repo- or org-level** secrets (not environment-scoped, and **not** the dev3 names), confirm the deploy target name (`emr-3-test` assumed; set `TEST3_DEPLOY_TARGET` if different). Until then nothing changes operationally.

## Verification

`actionlint` clean. The gate logic was extracted from the YAML and executed under all five permutations — provisioned+manual, unprovisioned+auto (green no-op + warning), unprovisioned+manual (loud failure), provisioned+auto with all rc images live on Docker Hub (verified against the real `3.7.1-rc.1` tags), and provisioned+auto with incomplete images (deferred). The SSH deploy itself is infrastructure-blocked pre-provisioning; test contract: once provisioned, a manual dispatch must refresh test3 to the current `:qa` images. The `release-qa.yml` summary-text change re-runs the release-workflow regression suite on this PR (passing).

Two adversarial review rounds hardened this PR (every GitHub Actions semantics claim empirically verified against real runs and deployment records):
- Round 1: the inherited-secret-names hazard (dev3's org/repo-level `DEPLOY_SSH_KEY`/`SERVER_HOST` would have satisfied a generic gate and pointed the deploy at dev3's server), the single-build trigger gap, and phantom deployment records for no-op runs.
- Round 2: the concurrency pending-slot cancel hazard (a main-branch build completion could silently cancel the deciding RC trigger — fixed with per-ref gate groups + a newest-wins deploy group), Docker Hub errors conflated with not-yet-published (transport/429 now retry then fail red instead of falsely promising a later trigger), doc precision on secret level and manual-dispatch failure behavior, `permissions: {}`, broadened host-key types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017s7xqiMT8HZAC7MnhAY6mt
