### PR TITLE
(feat) Add o3 production deployment workflow and dev3 frontend schedule

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -8,8 +8,9 @@ Releases are driven by two GitHub Actions workflows (Actions tab → run with
 | Cut an RC + publish QA images | **Release: Cut QA (RC)** (`release-qa.yml`) | O3-CQR, O3-CUQR, O3-PQR (image-publish half) |
 | Finalize + publish production images | **Release: Promote to Production** (`release-promote.yml`) | "Deploy Reference Application 3.x" (build half) |
 
-The *server deployment* halves of those Bamboo jobs (refreshing
-test3/o3.openmrs.org) are **not** ported — see below.
+The *server deployment* halves have their own workflows
+(`deploy-test3.yml`, `deploy-o3.yml`) that activate once infrastructure
+provisions their secrets — see "Not (yet) ported" below.
 
 ## Release runbook
 
@@ -65,7 +66,15 @@ test3/o3.openmrs.org) are **not** ported — see below.
    `:<version>` and `:demo` images. It refuses to promote if commits landed
    on the release branch after the last RC, and re-running it after a partial
    failure resumes safely (including re-dispatching the image builds).
-6. **Announce** the release in `#openmrs3` and on OpenMRS Talk.
+6. **Deploy to production**: dispatch **Release: Deploy to o3
+   (production)** with the `release_version` once the promote image builds
+   finish. It verifies per image that the `:demo` Docker Hub digest equals
+   the `:<version>` digest before SSHing, and fails with instructions until
+   the `O3_DEPLOY_SSH_KEY` / `O3_SERVER_HOST` repo- or org-level secrets
+   are provisioned — until then use the Bamboo
+   [Deploy Reference Application 3.x](https://ci.openmrs.org/deploy/viewDeploymentProjectEnvironments.action?id=222593025)
+   project or `#infrastructure`.
+7. **Announce** the release in `#openmrs3` and on OpenMRS Talk.
 
 `main` is never pushed to by these workflows. When a (minor) release makes the
 development version on main stale, the RC workflow opens a version-bump PR —
@@ -95,9 +104,10 @@ review and merge it like any other PR.
 
 ## Bamboo decommission checklist
 
-Once the `TEST3_*` and `O3_*` secrets are provisioned and each deploy
-workflow has one successful run, nothing in the release path needs Bamboo.
-To retire:
+Items 1–3 and 5 can be retired once the `TEST3_*` and `O3_*` secrets are
+provisioned and each deploy workflow has one successful run; item 4 as soon
+as the schedule trigger is on main (no secrets involved). After that,
+nothing in the release path needs Bamboo. To retire:
 
 1. O3-CQR (Create initial QA release) and O3-CUQR (Create Updated QA
    Release) — replaced by `release-qa.yml`.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -107,14 +107,16 @@ review and merge it like any other PR.
 Each item has its own precondition — after all five, nothing in the
 release path needs Bamboo:
 
-- Item 1: retirable now (`release-qa.yml` already cut a real release's RCs).
+- Item 1: retirable now — `release-qa.yml` cut `3.7.1-rc.1` for a real
+  release; its rc.2+ update path (the O3-CUQR half) is exercised by the
+  regression suite, not yet by a production release.
 - Item 2: after `TEST3_*` secrets are provisioned and `deploy-test3.yml`
   has one successful deploy.
 - Item 3: after `O3_*` secrets are provisioned and `deploy-o3.yml` has one
   successful deploy.
-- Item 4: as soon as the schedule trigger is on main (it uses the same
-  Docker Hub credentials every build already uses — nothing new to
-  provision).
+- Item 4: as soon as the schedule trigger is on main (scheduled runs use
+  only the pre-existing Docker Hub and Maven credentials every build
+  already uses — nothing new to provision).
 - Item 5: independent — confirm with infrastructure at any time.
 
 To retire:

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -104,10 +104,20 @@ review and merge it like any other PR.
 
 ## Bamboo decommission checklist
 
-Items 1–3 and 5 can be retired once the `TEST3_*` and `O3_*` secrets are
-provisioned and each deploy workflow has one successful run; item 4 as soon
-as the schedule trigger is on main (no secrets involved). After that,
-nothing in the release path needs Bamboo. To retire:
+Each item has its own precondition — after all five, nothing in the
+release path needs Bamboo:
+
+- Item 1: retirable now (`release-qa.yml` already cut a real release's RCs).
+- Item 2: after `TEST3_*` secrets are provisioned and `deploy-test3.yml`
+  has one successful deploy.
+- Item 3: after `O3_*` secrets are provisioned and `deploy-o3.yml` has one
+  successful deploy.
+- Item 4: as soon as the schedule trigger is on main (it uses the same
+  Docker Hub credentials every build already uses — nothing new to
+  provision).
+- Item 5: independent — confirm with infrastructure at any time.
+
+To retire:
 
 1. O3-CQR (Create initial QA release) and O3-CUQR (Create Updated QA
    Release) — replaced by `release-qa.yml`.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -73,17 +73,43 @@ review and merge it like any other PR.
 
 ## Not (yet) ported
 
-- **Server container refreshes**: test3.openmrs.org has a workflow
-  (`deploy-test3.yml`) whose automatic runs no-op (and manual runs fail
-  with instructions) until infrastructure provisions the
-  `TEST3_DEPLOY_SSH_KEY` / `TEST3_SERVER_HOST` repo- or org-level
-  secrets. o3.openmrs.org
-  (`demo` images) has **no workflow yet** — its refresh remains entirely
-  with infrastructure, via the
-  [Deploy Reference Application 3.x](https://ci.openmrs.org/deploy/viewDeploymentProjectEnvironments.action?id=222593025)
-  deployment project or `#infrastructure`.
+- **Server container refreshes**: both environments have workflows that
+  activate once infrastructure provisions their secrets (repo- or
+  org-level; environment-scoped secrets are invisible to the gate jobs):
+  - test3.openmrs.org — `deploy-test3.yml`, `TEST3_DEPLOY_SSH_KEY` /
+    `TEST3_SERVER_HOST` (target default `emr-3-test`). Automatic after RC
+    builds; manual dispatch supported.
+  - o3.openmrs.org — `deploy-o3.yml`, `O3_DEPLOY_SSH_KEY` /
+    `O3_SERVER_HOST` (target default `emr-3-demo`). **Manual dispatch
+    only** (production stays human-initiated); verifies the `:demo`
+    Docker Hub digests match the promoted version before deploying.
+    Consider adding required reviewers to the `o3` environment for a
+    second approval gate.
+
+  Until provisioned, the Bamboo fallbacks are
+  [Publish QA Release](https://ci.openmrs.org/browse/O3-PQR) and
+  [Deploy Reference Application 3.x](https://ci.openmrs.org/deploy/viewDeploymentProjectEnvironments.action?id=222593025),
+  or `#infrastructure`.
 - Bamboo remains available as a fallback; these workflows use the same
   branch/tag/commit conventions it did.
+
+## Bamboo decommission checklist
+
+Once the `TEST3_*` and `O3_*` secrets are provisioned and each deploy
+workflow has one successful run, nothing in the release path needs Bamboo.
+To retire:
+
+1. O3-CQR (Create initial QA release) and O3-CUQR (Create Updated QA
+   Release) — replaced by `release-qa.yml`.
+2. O3-PQR (Publish QA Release) — image publishing replaced by the build
+   dispatches in `release-qa.yml`; the test3 deploy by `deploy-test3.yml`.
+3. Deploy Reference Application 3.x — builds replaced by
+   `release-promote.yml`; the o3 deploy by `deploy-o3.yml`.
+4. The Bamboo cron that dispatched Build Frontend several times a day —
+   replaced by the `schedule` trigger in `build-frontend.yml`.
+5. Any legacy tag-watching triggers on this repo (the old "Distribution
+   3.x Releases" project) — confirm with infrastructure nothing still
+   fires on pushed tags.
 
 ## Testing changes to these workflows
 

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -20,6 +20,12 @@ on:
         description: 'Docker image environment tag (e.g., dev3)'
         required: false
         default: 'dev3'
+  schedule:
+    # Rebuild the dev3 frontend regularly so it picks up newly published
+    # "next" ESM versions (replaces the Bamboo cron that dispatched this
+    # workflow several times a day — decommission that cron when this lands).
+    # Scheduled runs use the same defaults as an input-less dispatch.
+    - cron: '0 1,7,13,19 * * *'
 
 env:
   IMAGE: openmrs/openmrs-reference-application-3-frontend

--- a/.github/workflows/deploy-o3.yml
+++ b/.github/workflows/deploy-o3.yml
@@ -1,0 +1,123 @@
+name: 'Release: Deploy to o3 (production)'
+
+# Replaces the server-deployment half of the Bamboo "Deploy Reference
+# Application 3.x" project: refreshes o3.openmrs.org so it runs the :demo
+# images published by a "Release: Promote to Production" run.
+#
+# Manual dispatch ONLY — production deploys stay human-initiated, matching
+# the deliberate promotion click the Bamboo flow had. Infrastructure is
+# encouraged to add required reviewers to the `o3` GitHub environment for a
+# second approval gate; this workflow works with or without one.
+#
+# Before touching the server, the gate verifies that for each of the three
+# images the :<release_version> and :demo Docker Hub digests MATCH — promote
+# publishes both tags from the same build, so a mismatch means the promote
+# builds have not finished (or something else moved the demo tags) and
+# deploying would put the wrong bits on production.
+#
+# Same scoped-SSH pattern and hardening as deploy-test3.yml, with
+# o3-SPECIFIC secret names (O3_DEPLOY_SSH_KEY / O3_SERVER_HOST, repo or org
+# level — environment-scoped secrets are invisible to the gate job, and the
+# dev3 DEPLOY_SSH_KEY/SERVER_HOST names must not be reused). The remote
+# deploy target defaults to `emr-3-demo`; set the O3_DEPLOY_TARGET
+# repository variable if infrastructure uses another name.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version whose promotion is being deployed, e.g. 3.7.1 — used to verify the :demo tags carry exactly this release'
+        required: true
+      reset:
+        description: 'Fully resets the o3 instance (DESTROYS VOLUMES — demo data is rebuilt from scratch)'
+        type: boolean
+        default: false
+
+# No GITHUB_TOKEN use in either job.
+permissions: {}
+
+concurrency:
+  # ':' cannot appear in a git ref, keeping this outside any ref-derived
+  # namespace other workflows might use.
+  group: deploy-o3::production
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    name: Verify credentials and promoted images
+    if: github.repository_owner == 'openmrs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      go: ${{ steps.decide.outputs.go }}
+    steps:
+      - name: Decide whether to deploy
+        id: decide
+        env:
+          PROVISIONED: ${{ secrets.O3_DEPLOY_SSH_KEY != '' && secrets.O3_SERVER_HOST != '' }}
+          V: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { echo "::error::release_version must look like 3.7.1 (got: $V)"; exit 1; }
+          if [ "$PROVISIONED" != "true" ]; then
+            MSG="o3 deploy credentials are not provisioned: O3_DEPLOY_SSH_KEY / O3_SERVER_HOST must be REPO- or ORG-level secrets (environment-scoped secrets are invisible to this gate, and the dev3 DEPLOY_SSH_KEY/SERVER_HOST names must not be reused). Refresh o3 via the Bamboo Deploy Reference Application 3.x project or #infrastructure instead."
+            {
+              echo "## :warning: o3 was NOT deployed"
+              echo "$MSG"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::$MSG"; exit 1
+          fi
+          # Promote publishes :$V and :demo from the same build: their digests
+          # must match per image, or production would get the wrong bits.
+          for repo in backend frontend gateway; do
+            base="https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags"
+            v_digest=""; demo_digest=""
+            for attempt in 1 2 3; do
+              v_digest=$(curl -s --max-time 20 "$base/$V" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("digest",""))' 2>/dev/null || true)
+              demo_digest=$(curl -s --max-time 20 "$base/demo" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("digest",""))' 2>/dev/null || true)
+              if [ -n "$v_digest" ] && [ -n "$demo_digest" ]; then break; fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "$repo: Docker Hub lookup incomplete (attempt $attempt); retrying"
+                sleep $(( attempt * 15 ))
+              fi
+            done
+            if [ -z "$v_digest" ] || [ -z "$demo_digest" ]; then
+              echo "::error::could not read Docker Hub digests for $repo (:$V or :demo missing, or Hub unavailable) — did the promote image builds finish?"; exit 1
+            fi
+            if [ "$v_digest" != "$demo_digest" ]; then
+              echo "::error::$repo: the :demo tag does not carry release $V ($v_digest vs $demo_digest) — the promote builds have not finished, or another push moved :demo. Not deploying."; exit 1
+            fi
+            echo "$repo: :demo == :$V ✔ ($v_digest)"
+          done
+          echo "go=true" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    name: Deploy release images to o3 (production)
+    needs: gate
+    if: needs.gate.outputs.go == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: o3
+      url: https://o3.openmrs.org/openmrs/spa
+    steps:
+      - name: Deploy via scoped SSH
+        env:
+          DEPLOY_KEY: ${{ secrets.O3_DEPLOY_SSH_KEY }}
+          SERVER_HOST: ${{ secrets.O3_SERVER_HOST }}
+          DEPLOY_TARGET: ${{ vars.O3_DEPLOY_TARGET || 'emr-3-demo' }}
+          RESET_FLAGS: ${{ inputs.reset && ' --destroy-volumes' || '' }}
+        run: |
+          set -euo pipefail
+          [[ "$DEPLOY_TARGET" =~ ^[A-Za-z0-9][A-Za-z0-9-]*$ ]] \
+            || { echo "::error::O3_DEPLOY_TARGET must be a plain target name (got: $DEPLOY_TARGET)"; exit 1; }
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -t ed25519,ecdsa,rsa "$SERVER_HOST" >> ~/.ssh/known_hosts
+
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=yes \
+            "deploy@$SERVER_HOST" \
+            "deploy ${DEPLOY_TARGET}${RESET_FLAGS} --no-health-check"

--- a/.github/workflows/deploy-o3.yml
+++ b/.github/workflows/deploy-o3.yml
@@ -82,21 +82,39 @@ jobs:
             base="https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags"
             v_digest=""; demo_digest=""; v_code=""; demo_code=""
             for attempt in 1 2 3; do
+              # ': > "$body"' before every fetch and forcing the code to 000
+              # whenever curl itself fails are both load-bearing: curl can
+              # print a 200 from the headers while the body stalls to
+              # --max-time WITHOUT truncating -o output, which would leave
+              # the previous fetch's JSON in the shared body file and let a
+              # stalled :demo fetch "verify" against :$V's own digest.
               if [ -z "$v_digest" ]; then
-                v_code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/$V" || true)
+                : > "$body"
+                v_code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/$V") || v_code=000
                 if [ "$v_code" = "200" ]; then
                   v_digest=$(python3 -c 'import json,sys; d=json.load(sys.stdin).get("digest"); print(d if isinstance(d,str) else "")' < "$body" 2>/dev/null || true)
                 fi
               fi
               if [ -z "$demo_digest" ]; then
-                demo_code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/demo" || true)
+                : > "$body"
+                demo_code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/demo") || demo_code=000
                 if [ "$demo_code" = "200" ]; then
                   demo_digest=$(python3 -c 'import json,sys; d=json.load(sys.stdin).get("digest"); print(d if isinstance(d,str) else "")' < "$body" 2>/dev/null || true)
                 fi
               fi
               if [ -n "$v_digest" ] && [ -n "$demo_digest" ]; then break; fi
               if [ "$attempt" -lt 3 ]; then
-                echo "$repo: lookup incomplete (attempt $attempt; :$V HTTP ${v_code:-000}, :demo HTTP ${demo_code:-000}); retrying"
+                v_state="verified"
+                if [ -z "$v_digest" ]; then
+                  v_state="HTTP ${v_code:-000}"
+                  [ "$v_code" = "200" ] && v_state="HTTP 200 (unreadable/null digest)"
+                fi
+                demo_state="verified"
+                if [ -z "$demo_digest" ]; then
+                  demo_state="HTTP ${demo_code:-000}"
+                  [ "$demo_code" = "200" ] && demo_state="HTTP 200 (unreadable/null digest)"
+                fi
+                echo "$repo: lookup incomplete (attempt $attempt; :$V $v_state, :demo $demo_state); retrying"
                 sleep $(( attempt * 15 ))
               fi
             done

--- a/.github/workflows/deploy-o3.yml
+++ b/.github/workflows/deploy-o3.yml
@@ -72,32 +72,45 @@ jobs:
           # must match per image, or production would get the wrong bits.
           # The digest field is NULLABLE in the Hub API — a null must fail
           # closed (isinstance check), never compare equal on both sides.
+          # Each tag is fetched only until a digest is in hand (a transient
+          # 404/null on a RE-fetch must never discard a verified digest), and
+          # 404s are retried like other transient codes, with the terminal
+          # diagnosis made per tag from its last HTTP code.
+          body=$(mktemp)
+          trap 'rm -f "$body"' EXIT
           for repo in backend frontend gateway; do
             base="https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags"
-            v_digest=""; demo_digest=""
-            body=$(mktemp)
+            v_digest=""; demo_digest=""; v_code=""; demo_code=""
             for attempt in 1 2 3; do
-              code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/$V" || true)
-              if [ "$code" = "404" ]; then
-                echo "::error::$repo:$V is not on Docker Hub — did the promote image builds finish?"; exit 1
-              elif [ "$code" = "200" ]; then
-                v_digest=$(python3 -c 'import json,sys; d=json.load(sys.stdin).get("digest"); print(d if isinstance(d,str) else "")' < "$body" 2>/dev/null || true)
+              if [ -z "$v_digest" ]; then
+                v_code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/$V" || true)
+                if [ "$v_code" = "200" ]; then
+                  v_digest=$(python3 -c 'import json,sys; d=json.load(sys.stdin).get("digest"); print(d if isinstance(d,str) else "")' < "$body" 2>/dev/null || true)
+                fi
               fi
-              code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/demo" || true)
-              if [ "$code" = "404" ]; then
-                echo "::error::$repo:demo does not exist on Docker Hub — there is no promoted release to compare against."; exit 1
-              elif [ "$code" = "200" ]; then
-                demo_digest=$(python3 -c 'import json,sys; d=json.load(sys.stdin).get("digest"); print(d if isinstance(d,str) else "")' < "$body" 2>/dev/null || true)
+              if [ -z "$demo_digest" ]; then
+                demo_code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/demo" || true)
+                if [ "$demo_code" = "200" ]; then
+                  demo_digest=$(python3 -c 'import json,sys; d=json.load(sys.stdin).get("digest"); print(d if isinstance(d,str) else "")' < "$body" 2>/dev/null || true)
+                fi
               fi
               if [ -n "$v_digest" ] && [ -n "$demo_digest" ]; then break; fi
               if [ "$attempt" -lt 3 ]; then
-                echo "$repo: Docker Hub lookup incomplete (attempt $attempt, HTTP $code); retrying"
+                echo "$repo: lookup incomplete (attempt $attempt; :$V HTTP ${v_code:-000}, :demo HTTP ${demo_code:-000}); retrying"
                 sleep $(( attempt * 15 ))
               fi
             done
-            rm -f "$body"
-            if [ -z "$v_digest" ] || [ -z "$demo_digest" ]; then
-              echo "::error::could not read Docker Hub digests for $repo (Hub unavailable or returned null digests) — not deploying on unverified images. Re-run once Docker Hub recovers."; exit 1
+            if [ -z "$v_digest" ]; then
+              if [ "$v_code" = "404" ]; then
+                echo "::error::$repo:$V is not on Docker Hub — did the promote image builds finish?"; exit 1
+              fi
+              echo "::error::could not read the :$V digest for $repo (HTTP ${v_code:-000} or null digest) — not deploying on unverified images. Re-run once Docker Hub recovers."; exit 1
+            fi
+            if [ -z "$demo_digest" ]; then
+              if [ "$demo_code" = "404" ]; then
+                echo "::error::$repo:demo is not on Docker Hub (the promote may still be publishing, or Hub cache lag) — re-run shortly."; exit 1
+              fi
+              echo "::error::could not read the :demo digest for $repo (HTTP ${demo_code:-000} or null digest) — not deploying on unverified images. Re-run once Docker Hub recovers."; exit 1
             fi
             if [ "$v_digest" != "$demo_digest" ]; then
               echo "::error::$repo: the :demo tag does not carry release $V ($v_digest vs $demo_digest) — the promote builds have not finished, or another push moved :demo. Not deploying."; exit 1

--- a/.github/workflows/deploy-o3.yml
+++ b/.github/workflows/deploy-o3.yml
@@ -47,7 +47,10 @@ jobs:
     name: Verify credentials and promoted images
     if: github.repository_owner == 'openmrs'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Headroom for the worst case (every fetch stalling to --max-time across
+    # all repos ≈ 8 min) so the crafted ::error message renders instead of a
+    # generic job timeout.
+    timeout-minutes: 10
     outputs:
       go: ${{ steps.decide.outputs.go }}
     steps:

--- a/.github/workflows/deploy-o3.yml
+++ b/.github/workflows/deploy-o3.yml
@@ -70,20 +70,34 @@ jobs:
           fi
           # Promote publishes :$V and :demo from the same build: their digests
           # must match per image, or production would get the wrong bits.
+          # The digest field is NULLABLE in the Hub API — a null must fail
+          # closed (isinstance check), never compare equal on both sides.
           for repo in backend frontend gateway; do
             base="https://hub.docker.com/v2/repositories/openmrs/openmrs-reference-application-3-$repo/tags"
             v_digest=""; demo_digest=""
+            body=$(mktemp)
             for attempt in 1 2 3; do
-              v_digest=$(curl -s --max-time 20 "$base/$V" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("digest",""))' 2>/dev/null || true)
-              demo_digest=$(curl -s --max-time 20 "$base/demo" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("digest",""))' 2>/dev/null || true)
+              code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/$V" || true)
+              if [ "$code" = "404" ]; then
+                echo "::error::$repo:$V is not on Docker Hub — did the promote image builds finish?"; exit 1
+              elif [ "$code" = "200" ]; then
+                v_digest=$(python3 -c 'import json,sys; d=json.load(sys.stdin).get("digest"); print(d if isinstance(d,str) else "")' < "$body" 2>/dev/null || true)
+              fi
+              code=$(curl -s --max-time 20 -o "$body" -w '%{http_code}' "$base/demo" || true)
+              if [ "$code" = "404" ]; then
+                echo "::error::$repo:demo does not exist on Docker Hub — there is no promoted release to compare against."; exit 1
+              elif [ "$code" = "200" ]; then
+                demo_digest=$(python3 -c 'import json,sys; d=json.load(sys.stdin).get("digest"); print(d if isinstance(d,str) else "")' < "$body" 2>/dev/null || true)
+              fi
               if [ -n "$v_digest" ] && [ -n "$demo_digest" ]; then break; fi
               if [ "$attempt" -lt 3 ]; then
-                echo "$repo: Docker Hub lookup incomplete (attempt $attempt); retrying"
+                echo "$repo: Docker Hub lookup incomplete (attempt $attempt, HTTP $code); retrying"
                 sleep $(( attempt * 15 ))
               fi
             done
+            rm -f "$body"
             if [ -z "$v_digest" ] || [ -z "$demo_digest" ]; then
-              echo "::error::could not read Docker Hub digests for $repo (:$V or :demo missing, or Hub unavailable) — did the promote image builds finish?"; exit 1
+              echo "::error::could not read Docker Hub digests for $repo (Hub unavailable or returned null digests) — not deploying on unverified images. Re-run once Docker Hub recovers."; exit 1
             fi
             if [ "$v_digest" != "$demo_digest" ]; then
               echo "::error::$repo: the :demo tag does not carry release $V ($v_digest vs $demo_digest) — the promote builds have not finished, or another push moved :demo. Not deploying."; exit 1

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -318,7 +318,7 @@ jobs:
             echo "- Image builds: [watch here](https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3A$V) — they publish \`:$V\` and \`:demo\` images"
             echo ""
             echo "### Next steps"
-            echo "1. Refresh o3.openmrs.org: dispatch the *Release: Deploy to o3 (production)* workflow with release_version=$V once the image builds finish (it verifies the :demo digests match :$V before deploying; falls back with instructions until the O3_* secrets are provisioned — Bamboo *Deploy Reference Application 3.x* remains the alternative)."
+            echo "1. Refresh o3.openmrs.org: dispatch the *Release: Deploy to o3 (production)* workflow with release_version=$V once the image builds finish (it verifies the :demo digests match :$V before deploying). Until the O3_* secrets are provisioned it fails with instructions — use Bamboo *Deploy Reference Application 3.x* instead."
             echo "2. Verify the images and the module versions on o3.openmrs.org:"
             echo '```'
             echo "cosign verify openmrs/openmrs-reference-application-3-backend:$V --certificate-identity-regexp 'https://github.com/$GITHUB_REPOSITORY/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -318,7 +318,7 @@ jobs:
             echo "- Image builds: [watch here](https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3A$V) — they publish \`:$V\` and \`:demo\` images"
             echo ""
             echo "### Next steps"
-            echo "1. Refresh o3.openmrs.org so it picks up the new \`demo\` images (Bamboo deploy step / infrastructure — not yet ported)."
+            echo "1. Refresh o3.openmrs.org: dispatch the *Release: Deploy to o3 (production)* workflow with release_version=$V once the image builds finish (it verifies the :demo digests match :$V before deploying; falls back with instructions until the O3_* secrets are provisioned — Bamboo *Deploy Reference Application 3.x* remains the alternative)."
             echo "2. Verify the images and the module versions on o3.openmrs.org:"
             echo '```'
             echo "cosign verify openmrs/openmrs-reference-application-3-backend:$V --certificate-identity-regexp 'https://github.com/$GITHUB_REPOSITORY/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com"


### PR DESCRIPTION
## What

Closes the **last two Bamboo dependencies** in the O3 release path (following #1045 and #1046):

### 1. `deploy-o3.yml` — Release: Deploy to o3 (production)

The server-deployment half of Bamboo's *Deploy Reference Application 3.x* project.

- **Manual dispatch only** — production stays human-initiated, matching the deliberate promotion click the Bamboo flow had. Recommend infrastructure add **required reviewers to the `o3` environment** for a second approval gate (works with or without).
- **Digest verification before SSH**: takes a required `release_version` and verifies, per image, that the `:demo` Docker Hub digest **equals** the `:release_version` digest — promote publishes both tags from the same build, so a mismatch means the promote builds haven't finished or something else moved `:demo`. Refuses to deploy production with the wrong bits.
- Inherits every deploy-test3 hardening: o3-specific **repo/org-level** secret names (`O3_DEPLOY_SSH_KEY` / `O3_SERVER_HOST` — dev3's inherited names can't satisfy the gate), two-job gate/deploy split (no phantom deployment records), env-var secret handling, target shape guard (`emr-3-demo` default, `O3_DEPLOY_TARGET` variable override), `permissions: {}`, curl deadlines with retry, loud failure with Bamboo-fallback instructions until provisioned.

### 2. `build-frontend.yml` schedule

A `schedule` trigger (4× daily) replacing the Bamboo cron that dispatches this workflow to refresh dev3's frontend with newly published `next` ESMs. Scheduled runs use the same defaults as an input-less dispatch, and `deploy-dev3.yml`'s existing `workflow_run` trigger deploys them exactly as it does today.

### 3. Docs

RELEASING.md gets a consolidated server-refresh section and a **Bamboo decommission checklist** — once `TEST3_*`/`O3_*` secrets are provisioned and each deploy workflow has one successful run, O3-CQR, O3-CUQR, O3-PQR, the deploy project, and the frontend cron can all be retired.

## For infrastructure

- Add `O3_DEPLOY_SSH_KEY` + `O3_SERVER_HOST` as **repo- or org-level** secrets (not environment-scoped; not the dev3 names); confirm target `emr-3-demo`; optionally add required reviewers to the `o3` environment.
- Disable the Bamboo frontend-refresh cron once this merges (duplicates are harmless but wasteful).

## Verification

`actionlint` clean on the new/changed workflows (`build-frontend.yml`'s two shellcheck infos are pre-existing on untouched lines). The o3 gate was extracted from the YAML and executed under five permutations, including **two live Docker Hub digest checks against production reality**: `:demo` == `:3.7.0` (current production) → proceeds; `:demo` vs `:3.6.0` → refused with the exact mismatch message; missing tag and unprovisioned paths fail red with instructions. The SSH deploy is infrastructure-blocked pre-provisioning (contract: first provisioned dispatch with the current release version must refresh o3). The `release-promote.yml` summary change re-runs the release-workflow regression suite on this PR.

Three adversarial review rounds then hardened the gate (each empirically demonstrated its finding, and the final round found none):
- Round 2: verified digests now survive retry attempts (re-fetches could discard them); 404s retry with honest per-tag terminal diagnosis.
- Round 3: closed a stalled-transfer fail-open — curl can report the 200 from headers while the body stalls without truncating `-o` output, letting a stalled `:demo` fetch "verify" against stale `:$V` JSON; fixed with truncate-before-every-fetch AND trusting `-w` only on curl exit 0 (each alone sufficient, both proven by a stall-replication shim). A final convergence review found no remaining defects and recommended keeping the eight-permutation-verified bash gate over a speculative python rewrite.
- Round 1: Docker Hub's tag `digest` field is **nullable**, and the original parse would have compared `None == None` and green-lit production on unverified images — the gate now **fails closed** on null/unreadable digests (proven with a curl shim), 404s fail immediately with the dispatched-too-early message instead of burning retry sleeps, and the runbook gained the previously-missing production-deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017s7xqiMT8HZAC7MnhAY6mt

