### PR TITLE
(chore) Update demo content package to 1.9.3-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -58,7 +58,7 @@
     <tasks.version>2.1.0</tasks.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
-    <reference-demo-content.version>1.9.2-SNAPSHOT</reference-demo-content.version>
+    <reference-demo-content.version>1.9.3-SNAPSHOT</reference-demo-content.version>
   </properties>
 
   <dependencies>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -58,7 +58,7 @@
     <tasks.version>2.1.0</tasks.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
-    <reference-demo-content.version>1.9.1</reference-demo-content.version>
+    <reference-demo-content.version>1.9.2-SNAPSHOT</reference-demo-content.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Bumps the reference demo content package (`reference-demo-content.version`) from `1.9.1` to `1.9.3-SNAPSHOT` in `distro/pom.xml`.