### PR TITLE
(chore) Update module versions for 3.7.1

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -23,9 +23,9 @@
 
     <!-- track module versions
          we do so here so that we can utilise Maven to track updates, etc. -->
-    <openmrs.version>2.8.7</openmrs.version>
+    <openmrs.version>2.8.8</openmrs.version>
     <initializer.version>2.12.0</initializer.version>
-    <fhir2.version>4.1.0</fhir2.version>
+    <fhir2.version>4.2.0</fhir2.version>
     <webservices.rest.version>3.5.0</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
     <patientdocuments.version>1.1.0</patientdocuments.version>
@@ -58,7 +58,7 @@
     <tasks.version>2.1.0</tasks.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
-    <reference-demo-content.version>1.9.1</reference-demo-content.version>
+    <reference-demo-content.version>1.9.2</reference-demo-content.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary

Updates module versions in `distro/pom.xml` for the 3.7.1 release:

- **content demo package** (`reference-demo-content`): 1.9.1 → 1.9.2
- **fhir2**: 4.1.0 → 4.2.0
- **openmrs**: 2.8.7 → 2.8.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)