### PR TITLE
(chore) Bump patientdocuments to 1.2.0-SNAPSHOT for visit summary support

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -28,7 +28,7 @@
     <fhir2.version>4.2.0</fhir2.version>
     <webservices.rest.version>3.5.0</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
-    <patientdocuments.version>1.1.0</patientdocuments.version>
+    <patientdocuments.version>1.2.0-SNAPSHOT</patientdocuments.version>
     <idgen.version>5.0.4</idgen.version>
     <legacyui.version>2.1.0</legacyui.version>
     <metadatamapping.version>2.0.0</metadatamapping.version>


### PR DESCRIPTION
## Summary

Bumps the patientdocuments module from 1.1.0 to 1.2.0-SNAPSHOT so the reference application ships the version that contains the visit summary PDF pipeline and its REST endpoint.

## Related

Part of https://openmrs.atlassian.net/browse/O3-5667

## Other

