### PR TITLE
Feat: bump patientdocuments visit summary

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -28,7 +28,7 @@
     <fhir2.version>4.2.0</fhir2.version>
     <webservices.rest.version>3.5.0</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
-    <patientdocuments.version>1.1.0</patientdocuments.version>
+    <patientdocuments.version>1.2.0-SNAPSHOT</patientdocuments.version>
     <idgen.version>5.0.4</idgen.version>
     <legacyui.version>2.1.0</legacyui.version>
     <metadatamapping.version>2.0.0</metadatamapping.version>

--- a/gateway/default-ssl.conf.template
+++ b/gateway/default-ssl.conf.template
@@ -1,5 +1,5 @@
 map $request_uri $csp_header {
-  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self' blob:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
   "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src 'self' data:; frame-ancestors 'self';";
 }

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -1,5 +1,5 @@
 map $request_uri $csp_header {
-  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self' blob:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
   "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src 'self' data:; frame-ancestors 'self';";
 }


### PR DESCRIPTION
## Summary

Adds `frame-src 'self' blob:;` to the gateway CSP so blob-URL iframes under `/openmrs/spa/` can load. The patientdocuments visit-summary preview renders a generated PDF into a blob iframe; with no `frame-src`, the browser fell back to `default-src` (which lacks `blob:`) and blocked it.

## Changes

`frame-src 'self' blob:;` added to the `default` branch of the `$csp_header` map in both `default.conf.template` and `default-ssl.conf.template`. Other branches and `frame-ancestors` unchanged.

## Testing

`nginx -t` passes on the rendered template; `envsubst` leaves `blob:` and `${FRAME_ANCESTORS}` intact. Live confirmation once dev3 rebuilds the gateway.

