### PR TITLE
(fix) allow blob: object-src so SPA <object> PDF previews can load

### DIFF
--- a/gateway/default-ssl.conf.template
+++ b/gateway/default-ssl.conf.template
@@ -1,5 +1,5 @@
 map $request_uri $csp_header {
-  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self' blob:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; object-src 'self' blob:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
   "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src 'self' data:; frame-ancestors 'self';";
 }

--- a/gateway/default-ssl.conf.template
+++ b/gateway/default-ssl.conf.template
@@ -1,5 +1,5 @@
 map $request_uri $csp_header {
-  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self' blob:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
   "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src 'self' data:; frame-ancestors 'self';";
 }

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -1,5 +1,5 @@
 map $request_uri $csp_header {
-  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self' blob:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; object-src 'self' blob:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
   "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src 'self' data:; frame-ancestors 'self';";
 }

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -1,5 +1,5 @@
 map $request_uri $csp_header {
-  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-src 'self' blob:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
   "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src 'self' data:; frame-ancestors 'self';";
 }


### PR DESCRIPTION
 ### Summary
  Adds `object-src 'self' blob:;` to the gateway CSP so blob-URL `<object>` embeds a generated PDF into a blob `<object>`; with no `object-src`, the browser fell back to `default-src` (which lacks `blob:`) and blocked it.

  ### Changes
  `object-src 'self' blob:;` added to the default branch of the `$csp_header` map in both `default.conf.template` and `default-ssl.conf.template`. Other branches and `frame-ancestors` unchanged.
  
  ### Testing
  `nginx -t` passes on the rendered template; envsubst leaves `blob:` and `${FRAME_ANCESTORS}` intact. Verified end-to-end against a locally built gateway: the live `/openmrs/spa/` response carries `object-src 'self' blob:`, and a blob `<object>` PDF loads in Chromium with zero `securitypolicyviolation` events — the same page is blocked under `main`'s CSP.