### PR TITLE
Add auditlog backend and frontend modules

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -2,7 +2,7 @@ name: Build Backend
 
 on:
   push:
-    branches: [main]
+    branches: [auditlog]
     paths:
       - '.github/workflows/build-backend.yml'
       - 'Dockerfile'
@@ -11,31 +11,31 @@ on:
   workflow_dispatch:
     inputs:
       docker_image_tag:
-        description: 'Docker image tag (e.g., nightly)'
+        description: 'Docker image tag (e.g., nightly-auditlog)'
         required: false
-        default: 'nightly'
+        default: 'nightly-auditlog'
       docker_image_tag_version:
-        description: 'Docker image version tag (e.g., 3.7.x)'
+        description: 'Docker image version tag (e.g., 3.7.x-auditlog)'
         required: false
-        default: '3.7.x'
+        default: '3.7.x-auditlog'
       docker_image_tag_env:
-        description: 'Docker image environment tag (e.g., dev3)'
+        description: 'Docker image environment tag (e.g., audit)'
         required: false
-        default: 'dev3'
+        default: 'audit'
   workflow_call:
     inputs:
       docker_image_tag:
         required: false
         type: string
-        default: 'nightly'
+        default: 'nightly-auditlog'
       docker_image_tag_version:
         required: false
         type: string
-        default: '3.7.x'
+        default: '3.7.x-auditlog'
       docker_image_tag_env:
         required: false
         type: string
-        default: 'dev3'
+        default: 'audit'
       ref:
         required: false
         type: string
@@ -52,9 +52,9 @@ on:
 
 env:
   IMAGE: openmrs/openmrs-reference-application-3-backend
-  DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag || 'nightly' }}
-  DOCKER_IMAGE_TAG_VERSION: ${{ inputs.docker_image_tag_version || '3.7.x' }}
-  DOCKER_IMAGE_TAG_ENV: ${{ inputs.docker_image_tag_env || 'dev3' }}
+  DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag || 'nightly-auditlog' }}
+  DOCKER_IMAGE_TAG_VERSION: ${{ inputs.docker_image_tag_version || '3.7.x-auditlog' }}
+  DOCKER_IMAGE_TAG_ENV: ${{ inputs.docker_image_tag_env || 'audit' }}
   DOCKER_IMAGE_PLATFORMS: linux/amd64,linux/arm64
 
 concurrency:
@@ -115,7 +115,7 @@ jobs:
           push: true
           platforms: ${{ env.DOCKER_IMAGE_PLATFORMS }}
           build-args: |
-            MVN_COMMAND=deploy
+            MVN_COMMAND=install
             CACHE_BUST=${{ github.run_id }}
           secret-files: |
             m2settings=/tmp/maven-settings.xml
@@ -131,125 +131,3 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
-
-  build-and-publish-no-demo:
-    name: Build and Publish the Backend Image Without Demo Content
-    # Skip for release-candidate builds: nothing consumes an rc-no-demo
-    # image, and this job repeats the full multi-arch distro build.
-    if: github.repository == 'openmrs/openmrs-distro-referenceapplication' && !contains(inputs.docker_image_tag || 'nightly', '-rc.')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write   # required for cosign keyless signing via OIDC
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Create Maven settings.xml
-        run: |
-          cat > /tmp/maven-settings.xml << EOF
-          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-            <servers>
-              <server>
-                <id>openmrs-repo-releases</id>
-                <username>${MAVEN_REPO_USERNAME}</username>
-                <password>${MAVEN_REPO_API_KEY}</password>
-              </server>
-              <server>
-                <id>openmrs-repo-snapshots</id>
-                <username>${MAVEN_REPO_USERNAME}</username>
-                <password>${MAVEN_REPO_API_KEY}</password>
-              </server>
-            </servers>
-          </settings>
-          EOF
-        env:
-          MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
-          MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
-
-      - name: Build and push Docker image (no demo content)
-        id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          push: true
-          platforms: ${{ env.DOCKER_IMAGE_PLATFORMS }}
-          build-args: |
-            MVN_COMMAND=-Pno-demo install
-            CACHE_BUST=${{ github.run_id }}
-          secret-files: |
-            m2settings=/tmp/maven-settings.xml
-          tags: |
-            ${{ env.IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}-no-demo
-            ${{ env.IMAGE }}:${{ env.DOCKER_IMAGE_TAG_VERSION }}-no-demo
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
-
-      - name: Sign the image (keyless)
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: cosign sign --yes "${IMAGE}@${DIGEST}"
-
-  build-nightly-with-data:
-    name: Build and Publish Nightly With Data Images
-    needs: build-and-publish
-    if: github.repository == 'openmrs/openmrs-distro-referenceapplication' && (inputs.docker_image_tag || 'nightly') == 'nightly'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write   # required for cosign keyless signing via OIDC
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: Pull nightly images
-        run: docker compose -f docker-compose-no-volumes.yml pull
-
-      - name: Start backend and database
-        run: docker compose -f docker-compose-no-volumes.yml up -d
-
-      - name: Wait for OpenMRS to be ready
-        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
-
-      - name: Commit containers
-        run: |
-          backend_container_id=$(docker ps --filter ancestor=openmrs/openmrs-reference-application-3-backend:nightly --format '{{.ID}}')
-          db_container_id=$(docker ps --filter ancestor=mariadb:10.8.2 --format '{{.ID}}')
-          docker commit $backend_container_id openmrs/openmrs-reference-application-3-backend:nightly-with-data
-          docker commit $db_container_id openmrs/openmrs-reference-application-3-db:nightly-with-data
-
-      - name: Push images
-        run: |
-          docker push openmrs/openmrs-reference-application-3-backend:nightly-with-data
-          docker push openmrs/openmrs-reference-application-3-db:nightly-with-data
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
-
-      - name: Sign the images (keyless)
-        run: |
-          backend_digest=$(docker inspect --format='{{index .RepoDigests 0}}' openmrs/openmrs-reference-application-3-backend:nightly-with-data)
-          db_digest=$(docker inspect --format='{{index .RepoDigests 0}}' openmrs/openmrs-reference-application-3-db:nightly-with-data)
-          cosign sign --yes "$backend_digest"
-          cosign sign --yes "$db_digest"

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -2,38 +2,38 @@ name: Build Frontend
 
 on:
   push:
-    branches: [main]
+    branches: [auditlog]
     paths:
       - '.github/workflows/build-frontend.yml'
       - 'frontend/**'
   workflow_dispatch:
     inputs:
       docker_image_tag:
-        description: 'Docker image tag (e.g., nightly)'
+        description: 'Docker image tag (e.g., nightly-auditlog)'
         required: false
-        default: 'nightly'
+        default: 'nightly-auditlog'
       docker_image_tag_version:
-        description: 'Docker image version tag (e.g., 3.7.x)'
+        description: 'Docker image version tag (e.g., 3.7.x-auditlog)'
         required: false
-        default: '3.7.x'
+        default: '3.7.x-auditlog'
       docker_image_tag_env:
-        description: 'Docker image environment tag (e.g., dev3)'
+        description: 'Docker image environment tag (e.g., audit)'
         required: false
-        default: 'dev3'
+        default: 'audit'
   workflow_call:
     inputs:
       docker_image_tag:
         required: false
         type: string
-        default: 'nightly'
+        default: 'nightly-auditlog'
       docker_image_tag_version:
         required: false
         type: string
-        default: '3.7.x'
+        default: '3.7.x-auditlog'
       docker_image_tag_env:
         required: false
         type: string
-        default: 'dev3'
+        default: 'audit'
       ref:
         required: false
         type: string
@@ -47,16 +47,12 @@ on:
         required: true
       MAVEN_REPO_API_KEY:
         required: true
-  repository_dispatch:
-    types: [frontend-prerelease]
-  schedule:
-    - cron: '0 1,7,13,19 * * *'
 
 env:
   IMAGE: openmrs/openmrs-reference-application-3-frontend
-  DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag || 'nightly' }}
-  DOCKER_IMAGE_TAG_VERSION: ${{ inputs.docker_image_tag_version || '3.7.x' }}
-  DOCKER_IMAGE_TAG_ENV: ${{ inputs.docker_image_tag_env || 'dev3' }}
+  DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag || 'nightly-auditlog' }}
+  DOCKER_IMAGE_TAG_VERSION: ${{ inputs.docker_image_tag_version || '3.7.x-auditlog' }}
+  DOCKER_IMAGE_TAG_ENV: ${{ inputs.docker_image_tag_env || 'audit' }}
   DOCKER_IMAGE_PLATFORMS: linux/amd64,linux/arm64
 
 concurrency:
@@ -106,63 +102,3 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
-
-      - name: Extract spa-assemble-config.json
-        run: |
-          IMAGE="${{ env.IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}"
-          CONTAINER_ID=$(docker create $IMAGE)
-          docker cp $CONTAINER_ID:/usr/share/nginx/html/spa-assemble-config.json ./spa-assemble-config.json
-
-      - name: Upload spa-assemble-config.json as artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: spa-assemble-config
-          path: ./spa-assemble-config.json
-          retention-days: 1
-
-  extract-and-deploy:
-    name: Extract config and Deploy to Maven
-    runs-on: ubuntu-latest
-    needs: build-and-publish
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Download spa-assemble-config.json
-        uses: actions/download-artifact@v4
-        with:
-          name: spa-assemble-config
-          path: ./frontend/src/main/resources/
-
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '21'
-
-      - name: Create Maven settings.xml
-        run: |
-          mkdir -p "$HOME/.m2"
-          cat > "$HOME/.m2/settings.xml" << EOF
-          <settings>
-            <servers>
-              <server>
-                <id>openmrs-repo-releases</id>
-                <username>${MAVEN_REPO_USERNAME}</username>
-                <password>${MAVEN_REPO_API_KEY}</password>
-              </server>
-              <server>
-                <id>openmrs-repo-snapshots</id>
-                <username>${MAVEN_REPO_USERNAME}</username>
-                <password>${MAVEN_REPO_API_KEY}</password>
-              </server>
-            </servers>
-          </settings>
-          EOF
-        env:
-          MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
-          MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
-
-      - name: Deploy frontend artifact
-        run: mvn deploy -Pfrontend -pl frontend -s $HOME/.m2/settings.xml -B

--- a/distro/distro-no-demo.properties
+++ b/distro/distro-no-demo.properties
@@ -34,4 +34,5 @@ omod.bedmanagement=${bedmanagement.version}
 omod.stockmanagement=${stockmanagement.version}
 omod.billing=${billing.version}
 omod.tasks=${tasks.version}
+omod.auditlogweb=${auditlogweb.version}
 content.referenceapplication=${reference-content.version}

--- a/distro/distro.properties
+++ b/distro/distro.properties
@@ -35,5 +35,6 @@ omod.bedmanagement=${bedmanagement.version}
 omod.stockmanagement=${stockmanagement.version}
 omod.billing=${billing.version}
 omod.tasks=${tasks.version}
+omod.auditlogweb=${auditlogweb.version}
 content.referenceapplication=${reference-content.version}
 content.referenceapplication-demo=${reference-demo-content.version}

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -56,6 +56,7 @@
     <stockmanagement.version>3.0.0</stockmanagement.version>
     <billing.version>2.4.0</billing.version>
     <tasks.version>2.1.0</tasks.version>
+    <auditlogweb.version>1.1.0-SNAPSHOT</auditlogweb.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
     <reference-demo-content.version>1.9.3-SNAPSHOT</reference-demo-content.version>
@@ -243,6 +244,12 @@
       <groupId>org.openmrs.module</groupId>
       <artifactId>tasks-omod</artifactId>
       <version>${tasks.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openmrs.module</groupId>
+      <artifactId>auditlogweb-omod</artifactId>
+      <version>${auditlogweb.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/docker-compose-no-volumes.yml
+++ b/docker-compose-no-volumes.yml
@@ -13,6 +13,7 @@ services:
       OMRS_CONFIG_CONNECTION_DATABASE: openmrs
       OMRS_CONFIG_CONNECTION_USERNAME: ${OPENMRS_DB_USER:-openmrs}
       OMRS_CONFIG_CONNECTION_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
+      OMRS_EXTRA_HIBERNATE_INTEGRATION_ENVERS_ENABLED: "true"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       OMRS_CONFIG_CONNECTION_DATABASE: openmrs
       OMRS_CONFIG_CONNECTION_USERNAME: ${OMRS_DB_USER:-openmrs}
       OMRS_CONFIG_CONNECTION_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
+      OMRS_EXTRA_HIBERNATE_INTEGRATION_ENVERS_ENABLED: "true"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s

--- a/frontend/spa-assemble-config.json
+++ b/frontend/spa-assemble-config.json
@@ -2,6 +2,7 @@
   "frontendModules": {
     "@openmrs/esm-active-visits-app": "next",
     "@openmrs/esm-appointments-app": "next",
+    "@openmrs/esm-audit-log-app": "next",
     "@openmrs/esm-bed-management-app": "next",
     "@openmrs/esm-billing-app": "next",
     "@openmrs/esm-cohort-builder-app": "next",


### PR DESCRIPTION
- Add auditlogweb-omod 1.1.0-SNAPSHOT to distro/pom.xml, distro.properties, and distro-no-demo.properties
- Add @openmrs/esm-audit-log-app (next) to the SPA assemble config
- Trigger the builds on pushes to the auditlog branch