### PR TITLE
Enable frontend image to serve pre-compressed files

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,6 +22,26 @@ http {
 
   access_log /var/log/nginx/access.log combined if=$loggable;
 
+  # Select suffix based on Accept header, ignoring if q=0 or 0.0
+  map $http_accept_encoding $enc_suffix {
+    default                                            "";
+    "~*\bbr\b(?!\s*;\s*q=0(\.0+)?(\s*[,;]|\s*$))"      ".br";
+    "~*\bgzip\b(?!\s*;\s*q=0(\.0+)?(\s*[,;]|\s*$))"    ".gz";
+  }
+
+  # Fallback to gz if no br file exists
+  map $http_accept_encoding $enc_fallback {
+    default                                            "";
+    "~*\bgzip\b(?!\s*;\s*q=0(\.0+)?(\s*[,;]|\s*$))"    ".gz";
+  }
+
+  # Map from resolved URI to encoding header
+  map $uri $enc_header {
+    default    "";
+    "~\.br$"   "br";
+    "~\.gz$"   "gzip";
+  }
+
   server {
     listen  80;
     root    /usr/share/nginx/html;
@@ -33,9 +53,44 @@ http {
       try_files $uri =404;
     }
 
-    location ~* (\.js|openmrs\.(\w*\.)?css)$ {
+    location ~* \.js$ {
       expires 1y;
-      try_files $uri =404;
+      default_type application/javascript;
+      add_header Content-Encoding $enc_header;
+      add_header Vary Accept-Encoding;
+      try_files $uri$enc_suffix $uri$enc_fallback $uri =404;
+    }
+
+    location ~* openmrs\.(\w*\.)?css$ {
+      expires 1y;
+      default_type text/css;
+      add_header Content-Encoding $enc_header;
+      add_header Vary Accept-Encoding;
+      try_files $uri$enc_suffix $uri$enc_fallback $uri =404;
+    }
+
+    location ~* \.css$ {
+      add_header Cache-Control "no-cache, must-revalidate";
+      default_type text/css;
+      add_header Content-Encoding $enc_header;
+      add_header Vary Accept-Encoding;
+      try_files $uri$enc_suffix $uri$enc_fallback $uri =404;
+    }
+
+    location ~* \.json$ {
+      add_header Cache-Control "no-cache, must-revalidate";
+      default_type application/json;
+      add_header Content-Encoding $enc_header;
+      add_header Vary Accept-Encoding;
+      try_files $uri$enc_suffix $uri$enc_fallback $uri =404;
+    }
+
+    location ~* \.svg$ {
+      add_header Cache-Control "no-cache, must-revalidate";
+      default_type image/svg+xml;
+      add_header Content-Encoding $enc_header;
+      add_header Vary Accept-Encoding;
+      try_files $uri$enc_suffix $uri$enc_fallback $uri =404;
     }
 
     # handle anything with a "." that's not an HTML file


### PR DESCRIPTION
In O3-5872 / [this PR](https://github.com/openmrs/openmrs-esm-core/pull/1838) we added the capability to build pre-compressed frontend files. This adds the necessary rules to the frontend image's nginx config to actually serve them. The goal of the pre-compressed files is to allow us to maximally compress the files that we're serving to reduce the network traffic necessary. Files not covered by the rules here are still gzipped by the gateway if possible.