### PR TITLE
(chore) Bump queue module to 3.1.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -35,7 +35,7 @@
     <openconceptlab.version>3.2.0</openconceptlab.version>
     <attachments.version>4.0.0</attachments.version>
     <referencedemodata.version>2.6.1</referencedemodata.version>
-    <queue.version>3.0.0</queue.version>
+    <queue.version>3.1.0-SNAPSHOT</queue.version>
     <appointments.version>2.1.0</appointments.version>
     <teleconsultation.version>2.0.0</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>


### PR DESCRIPTION
## Summary

Bumps `queue.version` to `3.1.0-SNAPSHOT` so dev3 picks up the avg wait time fix ([queue#120](https://github.com/openmrs/openmrs-module-queue/pull/120)), which landed after the `queue-3.0.0` tag. Needed to test [O3-5760](https://openmrs.atlassian.net/browse/O3-5760) ([#2615](https://github.com/openmrs/openmrs-esm-patient-management/pull/2615)).

[O3-5760]: https://openmrs.atlassian.net/browse/O3-5760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ