### PR TITLE
(chore) Bump emrapi to 3.5.0-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -49,7 +49,7 @@
     <ordertemplates.version>2.2.0</ordertemplates.version>
     <patientflags.version>3.0.10</patientflags.version>
     <o3forms.version>2.3.0</o3forms.version>
-    <emrapi.version>3.4.0</emrapi.version>
+    <emrapi.version>3.5.0-SNAPSHOT</emrapi.version>
     <event.version>4.0.0</event.version>
     <bedmanagement.version>7.2.0</bedmanagement.version>
     <!-- Stock Management and Billing -->


### PR DESCRIPTION
Bump EMRAPI to have the new `/emrspi/doseFormGroups` endpoint implemented in https://github.com/openmrs/openmrs-module-emrapi/pull/293